### PR TITLE
De-hardcode Mumbai coords from the live-temp widget (#17)

### DIFF
--- a/frontend/src/app/components/LiveTempStrip.tsx
+++ b/frontend/src/app/components/LiveTempStrip.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Thermometer } from "lucide-react";
-import { fetchMumbaiTemp } from "@/lib/weather";
+import { MUMBAI } from "@/lib/city";
+import { fetchCityTemp } from "@/lib/weather";
 
 type Status = "loading" | "ok" | "unavailable";
 
 /**
- * Live Mumbai air temperature (Open-Meteo), framed as a methodology point rather
+ * Live air temperature (Open-Meteo), framed as a methodology point rather
  * than a decorative weather widget: it exists to make UCIP's own stated
  * LST-is-not-air-temperature limitation tangible with a real, live contrast.
  * On any fetch failure this shows an honest "unavailable" state — never a
@@ -20,7 +21,7 @@ export default function LiveTempStrip() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchMumbaiTemp().then((result) => {
+    fetchCityTemp(MUMBAI).then((result) => {
       if (cancelled) return;
       if (result) {
         setTempC(result.temperatureC);
@@ -48,10 +49,10 @@ export default function LiveTempStrip() {
           />
         </span>
         <Thermometer className="h-4 w-4 shrink-0 text-brand-teal" aria-hidden />
-        {status === "loading" && <span className="text-foreground">Checking Mumbai now…</span>}
+        {status === "loading" && <span className="text-foreground">Checking {MUMBAI.name} now…</span>}
         {status === "ok" && tempC !== null && (
           <span className="text-foreground">
-            Mumbai now{" "}
+            {MUMBAI.name} now{" "}
             <span className="font-mono font-medium text-foreground">{tempC.toFixed(1)}°C</span> air
           </span>
         )}

--- a/frontend/src/lib/city.ts
+++ b/frontend/src/lib/city.ts
@@ -1,0 +1,19 @@
+/**
+ * City configuration. UCIP's pipeline is city-agnostic; this is the single
+ * place the frontend learns which city it is showing, so city-specific widgets
+ * (live weather, map centre, copy) never hardcode a location.
+ */
+
+export type CityConfig = {
+  name: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+};
+
+export const MUMBAI: CityConfig = {
+  name: "Mumbai",
+  lat: 19.076,
+  lon: 72.877,
+  timezone: "Asia/Kolkata",
+};

--- a/frontend/src/lib/weather.ts
+++ b/frontend/src/lib/weather.ts
@@ -1,7 +1,8 @@
 /**
- * Live current air temperature for Mumbai, via Open-Meteo (api.open-meteo.com) —
- * free, no API key, no rate-limit auth. Used by `LiveTempStrip` to give a real,
- * live number to contrast against the map's land-surface-temperature proxy.
+ * Live current air temperature for the configured city, via Open-Meteo
+ * (api.open-meteo.com) — free, no API key, no rate-limit auth. Used by
+ * `LiveTempStrip` to give a real, live number to contrast against the map's
+ * land-surface-temperature proxy.
  *
  * Deliberately returns `null` on any failure rather than a stale or fabricated
  * value: UCIP's own product rule is "numbers are real, never invented," and a
@@ -9,25 +10,25 @@
  * satellite data does.
  */
 
-const MUMBAI_LAT = 19.076;
-const MUMBAI_LON = 72.877;
+import type { CityConfig } from "./city";
+
 const FETCH_TIMEOUT_MS = 5000;
 
-export type MumbaiTemp = {
+export type CityTemp = {
   temperatureC: number;
   observedAt: string;
 };
 
-export async function fetchMumbaiTemp(): Promise<MumbaiTemp | null> {
+export async function fetchCityTemp(city: CityConfig): Promise<CityTemp | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
     const url = new URL("https://api.open-meteo.com/v1/forecast");
-    url.searchParams.set("latitude", String(MUMBAI_LAT));
-    url.searchParams.set("longitude", String(MUMBAI_LON));
+    url.searchParams.set("latitude", String(city.lat));
+    url.searchParams.set("longitude", String(city.lon));
     url.searchParams.set("current", "temperature_2m");
-    url.searchParams.set("timezone", "Asia/Kolkata");
+    url.searchParams.set("timezone", city.timezone);
 
     const res = await fetch(url.toString(), { signal: controller.signal });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary

Resolves #17. UCIP's pipeline is city-agnostic but the live-temp widget hardcoded Mumbai's coordinates and city name.

## Changes

- Add `frontend/src/lib/city.ts`: a `CityConfig` type plus a `MUMBAI` constant (name, lat, lon, timezone)
- Refactor `frontend/src/lib/weather.ts`: `fetchMumbaiTemp` -> `fetchCityTemp(city: CityConfig)`, `MumbaiTemp` -> `CityTemp`; no hardcoded coords/timezone remain
- Update `frontend/src/app/components/LiveTempStrip.tsx`: passes `MUMBAI`, drives UI copy from `city.name`

## Verification

- `npm run lint` clean
- `npm run build` passes (all 13 routes prerendered)
- Behavior unchanged for the current single-city (Mumbai) deployment