### PR TITLE
feat: complete Metadata export in layout.tsx

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,12 +14,36 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"),
+  metadataBase: new URL(siteUrl),
   title: "UCIP: Urban Climate Intelligence Platform",
   description: "Mumbai ward-level heat vulnerability decision-support platform.",
+  keywords: [
+    "urban heat vulnerability",
+    "Mumbai",
+    "urban planning",
+    "climate resilience",
+    "heat island",
+    "ward-level data",
+    "climate intelligence",
+  ],
   manifest: "/site.webmanifest",
+  robots: {
+    index: true,
+    follow: true,
+  },
   openGraph: {
+    title: "UCIP: Urban Climate Intelligence Platform",
+    description: "Mumbai ward-level heat vulnerability decision-support platform.",
+    url: siteUrl,
+    siteName: "UCIP",
+    images: ["/og-image.png"],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
     title: "UCIP: Urban Climate Intelligence Platform",
     description: "Mumbai ward-level heat vulnerability decision-support platform.",
     images: ["/og-image.png"],


### PR DESCRIPTION
## What and why
Closes #30. Fills in the missing fields on the `Metadata` export in `frontend/src/app/layout.tsx`: `twitter` card block, `openGraph.type`/`url`/`siteName`, `robots` directive, and `keywords`. Without these, links to UCIP shared on Twitter/X or Slack got no rich preview.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [ ] Tests pass locally (`npm run lint && npm run build`) — both fail in this environment on a pre-existing, unrelated issue: installed TypeScript is 7.0.2, which `eslint-config-next`'s typescript-eslint and `next build`'s TS worker don't yet support (see typescript-eslint#10940). Not caused by this change (single-file metadata addition, no new deps); deferring to CI.
- [ ] Lint passes — same TS 7.0 environment issue as above.
- [ ] Docs / README updated if behaviour changed — N/A, metadata-only change.
- [ ] CHANGELOG updated under `## [Unreleased]` — skipped per maintainer.
- [x] No secrets, credentials, or personal paths committed