### PR TITLE
Add top-level Error Boundary for dashboard route

### DIFF
--- a/frontend/src/app/dashboard/error.tsx
+++ b/frontend/src/app/dashboard/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // TODO: hook up real error tracking (Sentry, etc.) here once one exists.
+    console.error("Dashboard render error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <h1 className="text-lg font-semibold text-foreground">Something went wrong</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        The dashboard hit an unexpected error. Try reloading, if it keeps happening
+        let us know.
+      </p>
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #34.

Adds `app/dashboard/error.tsx` using Next.js App Router's error boundary convention. Catches uncaught render-phase exceptions anywhere in the dashboard segment and shows a fallback UI ("Something went wrong" + Try again button) instead of blanking the page. Logs to console with a TODO for where real error tracking hooks in later.

Scoped to the dashboard route by design — App Router error boundaries only catch errors within their own segment, so the landing page and other routes are unaffected.

**Verification**
- `tsc --noEmit`: clean
- `next build`'s internal TypeScript step currently fails on `main` too (TypeScript 7.0.2 vs Next's expected compiler API) — confirmed pre-existing and unrelated by building `main` without this file