### PR TITLE
Orchestrate the pipeline, schedule it, diff refreshes, and publish the methodology report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      # Only pytest, not pipeline/requirements.txt's geospatial/GEE stack: the tests
-      # under pipeline/tests/ exercise diff_snapshots.py, which has no third-party
-      # dependencies (stdlib json only), so this stays a fast, credential-free check.
+      # requirements-dev.txt only, not requirements.txt's full geospatial/GEE stack
+      # (geopandas, rasterio, osmnx, scikit-learn, scipy, matplotlib, supabase) --
+      # pipeline/tests/ doesn't need any of that. It DOES need earthengine-api and
+      # cryptography (both in requirements-dev.txt) for test_gee_auth.py, which
+      # covers _gee_auth.py's credential-routing logic -- the highest-risk new code
+      # in the pipeline orchestration work, and worth actually running here rather
+      # than only locally. No real GEE credentials or network calls are used;
+      # ee.Initialize is monkeypatched in every test.
       - run: pip install -r pipeline/requirements-dev.txt
       - run: pytest pipeline/tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,16 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test --if-present
+
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      # Only pytest, not pipeline/requirements.txt's geospatial/GEE stack: the tests
+      # under pipeline/tests/ exercise diff_snapshots.py, which has no third-party
+      # dependencies (stdlib json only), so this stays a fast, credential-free check.
+      - run: pip install -r pipeline/requirements-dev.txt
+      - run: pytest pipeline/tests/

--- a/.github/workflows/pipeline-refresh.yml
+++ b/.github/workflows/pipeline-refresh.yml
@@ -1,0 +1,121 @@
+# Scheduled data refresh (issue #58), on the cadence documented in
+# pipeline/README.md#refresh-cadence-issue-57: the pipeline is satellite- and
+# WorldPop-driven data that changes monthly at best, so this runs monthly, not
+# daily. Live weather is intentionally NOT run from here — it's fetched
+# client-side per page load by frontend/src/lib/weather.ts and needs no cron.
+#
+# NOT verified end-to-end: this workflow has never run against real Earth Engine
+# or Supabase credentials. This fork/PR has none configured, `earthengine
+# authenticate` cannot be run headlessly here, and there is no way to trigger a
+# live GitHub Actions run against upstream's secrets from a contributor's fork.
+# Every secret below is a placeholder name the maintainer needs to add under
+# Settings > Secrets > Actions before this can run for real. See the PR
+# description for exactly what was and wasn't testable.
+#
+# Required repo secrets:
+#   GEE_PROJECT                 Earth Engine project id (see .env.example)
+#   GEE_SERVICE_ACCOUNT_JSON    Full service-account key JSON (see pipeline/_gee_auth.py)
+#   NEXT_PUBLIC_SUPABASE_URL    Supabase project URL
+#   SUPABASE_SERVICE_ROLE_KEY   Supabase service-role key (server-side upsert only)
+
+name: Pipeline refresh
+
+on:
+  schedule:
+    # 03:17 UTC on the 1st of each month. Off the top of the hour on purpose —
+    # avoids piling onto GitHub's :00 cron stampede on shared runners.
+    - cron: "17 3 1 * *"
+  workflow_dispatch:
+    inputs:
+      include_spike:
+        description: "Also run 00_gee_spike.py as a GEE connectivity smoke test"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pipeline-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: "pip"
+          cache-dependency-path: pipeline/requirements.txt
+
+      - name: Install pipeline dependencies
+        working-directory: pipeline
+        run: pip install -r requirements.txt
+
+      - name: Snapshot pre-refresh data/ as the diff baseline
+        # diff_snapshots.py (#61) needs the PREVIOUS run's output to compare
+        # against. Copying it before run_pipeline.py overwrites data/ is the
+        # cheapest way to have both "before" and "after" on disk at once.
+        run: cp -r data data-baseline
+
+      - name: Run orchestrated pipeline
+        working-directory: pipeline
+        env:
+          GEE_PROJECT: ${{ secrets.GEE_PROJECT }}
+          GEE_SERVICE_ACCOUNT_JSON: ${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ "${{ inputs.include_spike }}" = "true" ]; then
+            python run_pipeline.py --include-spike
+          else
+            python run_pipeline.py
+          fi
+
+      - name: Compute alert-worthy diff against the previous run
+        working-directory: pipeline
+        run: |
+          python diff_snapshots.py \
+            --old-dir ../data-baseline \
+            --new-dir ../data \
+            --out ../data/pipeline_diff.json
+
+      - name: Upload run log and diff as workflow artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-refresh-${{ github.run_id }}
+          path: |
+            data/pipeline_run_log.json
+            data/pipeline_diff.json
+          if-no-files-found: warn
+
+      - name: Build PR body from the diff summary
+        id: diff_summary
+        run: |
+          echo "body<<PR_BODY_EOF" >> "$GITHUB_OUTPUT"
+          echo "Automated monthly pipeline refresh (schedule: \`17 3 1 * *\`, UTC)." >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          python pipeline/format_diff_summary.py data/pipeline_diff.json >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"
+          echo "## Scope" >> "$GITHUB_OUTPUT"
+          echo "- This PR contains only regenerated pipeline output (data/, frontend/public/*.json)." >> "$GITHUB_OUTPUT"
+          echo "- Per-user \"saved ward\" alert filtering and email delivery are out of scope pending issue #59." >> "$GITHUB_OUTPUT"
+          echo "PR_BODY_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Open a PR with the refreshed data
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(pipeline): monthly automated data refresh"
+          branch: automated/pipeline-refresh
+          delete-branch: true
+          title: "Automated monthly pipeline refresh"
+          body: ${{ steps.diff_summary.outputs.body }}
+          labels: automated,data-refresh
+          add-paths: |
+            data/**
+            frontend/public/*.json

--- a/.github/workflows/pipeline-refresh.yml
+++ b/.github/workflows/pipeline-refresh.yml
@@ -17,6 +17,15 @@
 #   GEE_SERVICE_ACCOUNT_JSON    Full service-account key JSON (see pipeline/_gee_auth.py)
 #   NEXT_PUBLIC_SUPABASE_URL    Supabase project URL
 #   SUPABASE_SERVICE_ROLE_KEY   Supabase service-role key (server-side upsert only)
+#
+# Known limitation: the diff baseline (see "Snapshot pre-refresh data/" below) is
+# whatever's committed on main when this workflow starts, not necessarily the last
+# MERGED refresh. If a previous automated-refresh PR is still open when the next
+# scheduled run fires, that run diffs against the same stale baseline again instead of
+# against the (still unmerged) previous refresh, so its diff can double-count changes
+# already sitting in the open PR. Not fixed here: doing so needs somewhere to persist
+# "the last refresh actually merged" (e.g. a git tag updated on merge), which is a
+# bigger change than this workflow's first version.
 
 name: Pipeline refresh
 
@@ -62,15 +71,36 @@ jobs:
         # cheapest way to have both "before" and "after" on disk at once.
         run: cp -r data data-baseline
 
+      - name: Resolve GEE_PROJECT
+        # An unconfigured secrets.* reference substitutes as an empty string, not as
+        # "absent". Every GEE-calling script resolves its project id with
+        # os.environ.get("GEE_PROJECT", "<its own hardcoded default>"), which only
+        # falls back when the variable is genuinely UNSET -- an env var explicitly set
+        # to "" still counts as present and defeats that fallback, which would send an
+        # empty project id to Earth Engine on the very first scheduled run after
+        # GEE_SERVICE_ACCOUNT_JSON is configured but GEE_PROJECT is not. Only export
+        # GEE_PROJECT here when the secret is actually non-empty, so an unconfigured
+        # secret leaves it genuinely unset and each script's own default applies.
+        run: |
+          if [ -n "${{ secrets.GEE_PROJECT }}" ]; then
+            echo "GEE_PROJECT=${{ secrets.GEE_PROJECT }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Run orchestrated pipeline
         working-directory: pipeline
         env:
-          GEE_PROJECT: ${{ secrets.GEE_PROJECT }}
           GEE_SERVICE_ACCOUNT_JSON: ${{ secrets.GEE_SERVICE_ACCOUNT_JSON }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        # inputs.include_spike only exists on a workflow_dispatch run; on the schedule
+        # trigger there are no inputs at all, so a bare `inputs.include_spike` reads as
+        # empty rather than the declared "false" default. That happens to still take
+        # the "else" branch below, but only by coincidence of empty-string comparison,
+        # not because the schedule trigger was ever meant to route through this input.
+        # Gating on github.event_name makes the schedule path explicit instead of
+        # accidental.
         run: |
-          if [ "${{ inputs.include_spike }}" = "true" ]; then
+          if [ "${{ github.event_name == 'workflow_dispatch' && inputs.include_spike }}" = "true" ]; then
             python run_pipeline.py --include-spike
           else
             python run_pipeline.py

--- a/.github/workflows/pipeline-refresh.yml
+++ b/.github/workflows/pipeline-refresh.yml
@@ -133,7 +133,7 @@ jobs:
           python pipeline/format_diff_summary.py data/pipeline_diff.json >> "$GITHUB_OUTPUT"
           echo "" >> "$GITHUB_OUTPUT"
           echo "## Scope" >> "$GITHUB_OUTPUT"
-          echo "- This PR contains only regenerated pipeline output (data/, frontend/public/*.json)." >> "$GITHUB_OUTPUT"
+          echo "- This PR contains only regenerated pipeline output (data/, frontend/public/)." >> "$GITHUB_OUTPUT"
           echo "- Per-user \"saved ward\" alert filtering and email delivery are out of scope pending issue #59." >> "$GITHUB_OUTPUT"
           echo "PR_BODY_EOF" >> "$GITHUB_OUTPUT"
 
@@ -146,6 +146,17 @@ jobs:
           title: "Automated monthly pipeline refresh"
           body: ${{ steps.diff_summary.outputs.body }}
           labels: automated,data-refresh
+          # Every extension the pipeline actually writes into frontend/public/ (see
+          # pipeline/README.md's "Frontend sync" table): *.json alone used to miss the
+          # .geojson layers (wards_hvi, cells_nbs, cells_ndvi_change) and the
+          # sensitivity chart .png this same PR added, which would have made every
+          # scheduled refresh silently commit nbs_recommendations.json while leaving
+          # the map/NBS/NDVI-change layers and the chart stale indefinitely. Matching
+          # unrelated static assets (logos, icons, robots.txt) under these globs is
+          # harmless: add-paths only stages files git already sees as changed, and the
+          # pipeline never touches those.
           add-paths: |
             data/**
             frontend/public/*.json
+            frontend/public/*.geojson
+            frontend/public/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ data/cache/
 # ad-hoc debug dumps
 *_debug.csv
 
+# run_pipeline.py's per-run log (regenerated every refresh, not source data)
+data/pipeline_run_log.json
+
 # Env / secrets
 .env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ data/cache/
 # run_pipeline.py's per-run log (regenerated every refresh, not source data)
 data/pipeline_run_log.json
 
+# diff_snapshots.py's output (regenerated per refresh)
+data/pipeline_diff.json
+
 # Env / secrets
 .env
 .env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,22 @@ yet — this section covers everything since the project started.
 - Sensitivity analysis: top-ward ranking verified stable under +/-20% weight perturbation.
 - Apache-2.0 license, full brand/design system (Inter + JetBrains Mono, teal/emerald
   tokens), light and dark themes.
+- `pipeline/run_pipeline.py`: an orchestrated runner that chains all 13 pipeline stages
+  in dependency order, stopping on the first hard failure and logging a structured
+  run report, so a data refresh is one command instead of running each stage by hand.
+- `.github/workflows/pipeline-refresh.yml`: a monthly GitHub Actions cron that runs the
+  orchestrated pipeline and opens a PR with the refreshed data, matching the cadence
+  documented in `pipeline/README.md` (satellite/demographic data does not change daily;
+  live weather already updates independently via `frontend/src/lib/weather.ts`).
+- `pipeline/diff_snapshots.py`: a diff-computation step that compares two pipeline runs'
+  output and reports per-ward HVI rank shifts, NBS recommendation changes, and
+  green-cover classification flips, with unit tests under `pipeline/tests/`.
+- `docs/HVI-methodology-report.md`: a standalone technical report expanding the existing
+  methodology and citation docs into a full writeup (PCA weighting, sensitivity
+  analysis, plantability filter, limitations, references).
 
 ### Fixed
+- Missing `python-dotenv` and `scipy` in `pipeline/requirements.txt` (used by
+  `07_load.py` and `08_sensitivity.py` respectively, but not previously listed).
 - Dashboard sidebar scroll, fullscreen popup theming in dark mode, ward search matching
   by locality name as well as ward code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,11 @@ pip install -r requirements.txt
 earthengine authenticate     # needs your own Google Earth Engine account
 ```
 
-The pipeline scripts (`00`–`09`) require a Google Earth Engine project and Supabase
+The pipeline scripts (`00`–`12`) require a Google Earth Engine project and Supabase
 credentials to run end-to-end; the committed GeoJSON snapshots in `data/` let the frontend
-run without either.
+run without either. Run the full chain in order with `python pipeline/run_pipeline.py`
+rather than invoking each script by hand; see [pipeline/README.md](pipeline/README.md)
+for usage, the monthly refresh cadence, and the post-refresh change-diff tool.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ docs/       Methodology, citations, screenshots
   plantability filter, mirroring the in-app `/methodology` page.
 - [docs/references.md](docs/references.md) - the citation table backing every variable and
   weight, with DOIs.
+- [docs/HVI-methodology-report.md](docs/HVI-methodology-report.md) - a standalone technical
+  report expanding the methodology and references above into a full writeup with real
+  pipeline output (PCA weights, sensitivity analysis results, plantability-filter numbers).
+- [pipeline/README.md](pipeline/README.md) - running the pipeline as one orchestrated
+  refresh, the refresh cadence split, and the post-refresh change-diff tool.
 
 ## Contributing
 

--- a/docs/HVI-methodology-report.md
+++ b/docs/HVI-methodology-report.md
@@ -1,0 +1,315 @@
+# A Transparent, Literature-Weighted Heat Vulnerability Index for Mumbai's 24 Wards
+
+**A standalone technical report for the Urban Cooling Intervention Platform (UCIP)**
+
+*Status: internal technical writeup, polished for external publication (e.g. a personal
+research page, SSRN, or arXiv's econ/physics-adjacent categories). Not yet submitted
+anywhere; this document is the writeup itself, prepared per issue #66. All figures below
+are read directly from this repository's committed pipeline output
+(`data/hvi_pca_log.json`, `data/sensitivity.json`, `data/nbs_recommendations.json`,
+`data/cells_ndvi_change.geojson`) and pipeline source (`pipeline/05_hvi.py`,
+`pipeline/06_nbs.py`, `pipeline/08_sensitivity.py`, `pipeline/09_ndvi_change.py`,
+`frontend/src/lib/coefficients.ts`) as of this writing, not re-derived or estimated.*
+
+---
+
+## Abstract
+
+Urban heat is not distributed evenly across a city, and neither is the capacity to
+adapt to it. This report documents the Heat Vulnerability Index (HVI) computed by the
+Urban Cooling Intervention Platform (UCIP) for Mumbai's 24 Brihanmumbai Municipal
+Corporation (BMC) wards: a seven-indicator, Principal Component Analysis (PCA)-weighted
+index built on dry-season satellite land surface temperature and vegetation data,
+WorldPop demographic layers, OpenStreetMap hospital access, and Datameet administrative
+and slum-cluster boundaries. We describe the indicator set and its directionality, the
+PCA weight-derivation procedure and its published fallback, a one-at-a-time
+weight-perturbation sensitivity analysis, the rule-based Nature-Based Solutions (NBS)
+recommendation engine, and its ecological plantability filter, which withholds
+afforestation recommendations for cells that are ecologically unsuitable for tree
+planting rather than recommending trees everywhere heat is high. Every indicator,
+weight, and coefficient in this report traces to either a value the pipeline actually
+computed from real geospatial data, or a specific cited publication; nothing here is an
+invented or illustrative placeholder. We close with the limitations we consider most
+important to state openly: land surface temperature is not air temperature, several
+demographic layers are proxies rather than ward-level census figures, and the cooling
+coefficients used elsewhere in the product are transferred from other cities rather
+than Mumbai-calibrated.
+
+## 1. Introduction and Motivation
+
+Heat is increasingly recognized as an urban public-health hazard, and IPCC AR6's
+Working Group II urban chapter frames adaptation planning as needing spatial
+granularity: a city-wide average temperature says little about which specific
+neighborhoods need intervention first, or what kind of intervention fits their
+physical and ecological constraints. UCIP's premise is that a heat-vulnerability tool
+is only useful to a city planner if it goes past "here is a heat map" to "here is which
+of your 24 administrative units to act on first, why, and with what intervention,"
+grounded in data the tool actually computed rather than expert judgment or arbitrary
+weighting.
+
+This report elevates the project's existing in-app methodology page (`/methodology`)
+and its outline-form source (`docs/methodology.md`, `docs/references.md`) into a
+self-contained technical document: one that can be read, cited, and checked without
+the surrounding product.
+
+## 2. Prior Art
+
+UCIP's design was informed by a comparison against existing heat-vulnerability and
+urban-cooling work, including the Mumbai Climate Action Plan (MCAP 2022), the RAND/Azhar
+et al. India district-level HVI (Azhar et al. 2017), IIT-Bombay's work on Mumbai's
+surface urban heat island, the C40 Urban Cooling Toolbox, and the Ahmedabad Heat Action
+Plan (documented via Knowlton et al. 2014). Relative to that prior art, UCIP's stated
+point of difference is combining (a) a transparent, literature-weighted index rather
+than a static or expert-weighted vulnerability score, (b) a rule-based NBS
+recommendation engine tied to that index, and (c) an ecological plantability filter
+that can reject afforestation on ecological grounds, described in Section 7.
+
+## 3. Study Area and Data
+
+The study area is Mumbai, analyzed at 1 km grid-cell resolution and rolled up to the
+city's 24 BMC administrative wards. The pipeline (`pipeline/01_grid.py`) builds this
+grid by clipping a fishnet to ward boundaries in a metric CRS (EPSG:32643, UTM zone
+43N) and assigning each cell to the ward containing its largest fragment. As of the
+data underlying this report, the grid contains 541 cells across all 24 wards.
+
+| Layer | Source | Access | Note |
+|---|---|---|---|
+| Land surface temperature (LST) | Landsat 8/9 Collection 2 Level-2, `ST_B10` | Google Earth Engine | Dry-season median composite, cloud/shadow-masked via `QA_PIXEL` |
+| NDVI (current + baseline) | Landsat 8/9 Collection 2 Level-2, `SR_B4`/`SR_B5` | Google Earth Engine | Two dry-season composites roughly nine years apart, for the green-cover-change layer (Section 8) |
+| Population density, elderly share | WorldPop age-sex structure, pinned to the `IND_2020` image | Google Earth Engine | **Proxy.** 2020 is the most recent year WorldPop publishes for India in this collection; the pin is explicit in `pipeline/03_vectors.py` rather than left to whichever vintage the API returns first |
+| Slum index | Datameet `slumClusters.geojson` (mapped cluster boundaries) | Repository data | **Proxy**, but based on observed cluster polygons rather than a modeled index |
+| Hospital access | OpenStreetMap `amenity=hospital` | `osmnx` / Overpass | Per-cell straight-line distance to the nearest hospital centroid |
+| Impervious / built-up surface, land-cover class | ESA WorldCover v200 | Google Earth Engine | Also the input to the plantability filter (Section 7) |
+| Ward boundaries | Datameet BMC ward boundaries | Repository data | 24 features, validated against Mumbai's known extent |
+
+## 4. Indicators and Directionality
+
+Seven indicators feed the index, each assigned a direction reflecting whether a higher
+raw value indicates *more* vulnerability (`+1`) or *less* (`-1`, i.e. inverted before
+scoring):
+
+| Indicator | Direction | Unit | Observed range (541 cells) |
+|---|---|---|---|
+| `LST_C` (land surface temperature) | + | °C (land surface, not air) | 26.24 to 39.95 |
+| `NDVI` (vegetation index) | − | unitless index, not a canopy percentage | −0.07 to 0.71 |
+| `pop_density_km2` (population density) | + | people / km² | 16 to 115,272 |
+| `elderly_pct` (elderly share, 60+) | + | % (0-100), WorldPop 2020 proxy | 4.02 to 5.59 |
+| `slum_pct` (slum-cluster coverage) | + | % (0-100), mapped-boundary proxy | 0.00 to 68.55 |
+| `hospital_dist_m` (distance to nearest hospital) | + | metres | 3.86 to 6199.03 |
+| `impervious_pct` (impervious surface share) | + | % (0-100) | 0.00 to 96.79 |
+
+`elderly_pct` spans only 1.6 percentage points across the entire city in this dataset,
+so on its own it separates wards weakly; the PCA weighting in Section 5 reflects this
+by assigning it the lowest weight of the seven indicators; the product's own UI copy
+does not lean on it as a standalone talking point.
+
+## 5. HVI Computation
+
+**Standardization.** Each indicator is z-standardized across all cells
+(`pipeline/05_hvi.py`): for indicator column $x$, $z = (x - \bar{x}) / \sigma_x$
+(population standard deviation, i.e. `ddof=0`), and then multiplied by its direction
+sign so that, after this step, a higher signed z-score always means "more
+vulnerable" for every indicator.
+
+**Weight derivation (PCA, Reid et al. 2009).** A Principal Component Analysis is fit
+on the seven signed z-score columns. The first principal component's explained
+variance ratio is checked against a floor of 0.30; if it is at or above that floor, the
+component's loadings are used to derive weights. The component is first sign-oriented
+so that a higher PC1 score means more vulnerable (checked by correlating PC1 scores
+against the signed `LST_C` z-score and flipping the sign if that correlation is
+negative), and the final weight for indicator $i$ is the absolute loading normalized
+across all seven indicators:
+
+$$w_i = \frac{|\ell_i|}{\sum_{j=1}^{7} |\ell_j|}$$
+
+where $\ell_i$ is indicator $i$'s (sign-oriented) PC1 loading. **Fallback.** If PC1's
+explained variance ratio is below the 0.30 floor, the pipeline treats the loadings as
+unstable for this single-city, single-snapshot sample and falls back to equal
+weighting across all seven indicators (the published component-level default per Reid
+et al. 2009), logging that the fallback fired and why.
+
+**Current run's values.** As of the pipeline output committed to this repository, PC1
+explained 58.0% of variance, comfortably above the 0.30 floor, so the PCA-derived
+weights below were used (fallback not triggered):
+
+| Indicator | PC1 loading | Weight |
+|---|---:|---:|
+| `LST_C` | 0.432 | 0.168 |
+| `NDVI` | 0.384 | 0.149 |
+| `pop_density_km2` | 0.432 | 0.168 |
+| `elderly_pct` | 0.197 | 0.077 |
+| `slum_pct` | 0.276 | 0.107 |
+| `hospital_dist_m` | −0.383 | 0.149 |
+| `impervious_pct` | 0.466 | 0.181 |
+
+These weights are **recomputed from the current run's data on every pipeline refresh**,
+not fixed constants; a materially different snapshot of Mumbai's cells could shift
+PC1's loadings and therefore these weights. What is fixed, and cited, is the *procedure*
+(PCA on signed z-scores, with the stated fallback), not any particular numeric weight.
+
+**HVI score.** Per cell, `HVI_raw` is the weighted sum of signed z-scores
+($\sum_i w_i z_i$), and the final `HVI` is `HVI_raw` linearly rescaled to 0-100 across
+all cells in the run (min mapped to 0, max to 100). Ward-level HVI is the unweighted
+mean of its member cells' scores, and ward rank is `HVI` sorted descending (rank 1 =
+most vulnerable). As of this run, the five highest-ranked wards are C, G/N, L, E, and
+F/S (HVI 73.6, 69.7, 65.8, 65.0, and 64.8 respectively), each driven primarily by
+`impervious_pct` except L, driven primarily by `LST_C`.
+
+**Explainability.** Per-cell, per-indicator contributions (`weight × signed z-score`)
+are stored alongside the score and shown as a ranked bar breakdown in the product.
+Because the index is a transparent weighted linear sum, this contribution decomposition
+*is* the full explanation of any given score; the project deliberately does not use a
+post-hoc explainability method (e.g. SHAP) because there is no black-box model to
+explain.
+
+## 6. Sensitivity Analysis
+
+A weight-transfer validity question, namely whether these literature-derived weights
+actually produce a stable, trustworthy ranking for Mumbai specifically, or whether
+small disagreements about the "right" weights would change which wards get
+prioritized, is addressed with a one-at-a-time perturbation study (`pipeline/08_sensitivity.py`): each
+of the seven weights is perturbed ±20% in turn, the remaining six renormalized to keep
+all weights summing to 1, and the ward ranking recomputed. Fourteen perturbation runs
+result (7 indicators × 2 directions), each compared to the unperturbed baseline ranking
+by Kendall's tau (rank-correlation over all 24 wards) and by top-5 overlap (how many of
+the baseline top-5 most-vulnerable wards remain in the perturbed top-5).
+
+**Results.** Mean Kendall tau across all 14 runs was 0.978 (1.0 = identical ranking),
+and mean top-5 overlap was 4.43 of 5. The top three wards by HVI (C, G/N, L) were
+unchanged in every one of the 14 perturbations. In 6 of the 14 runs the entire top-5
+set matched baseline exactly; in the remaining 8, exactly one ward (either the
+baseline's 4th- or 5th-ranked ward, F/S or E) was displaced by ward B, and overlap
+never fell below 4 of 5 in any run. No perturbation altered which ward ranked most
+vulnerable overall. We read this as the ward-priority ordering being stable under
+plausible weight disagreement at the top of the ranking, with some genuine sensitivity
+at the boundary between the 4th and 5th most-vulnerable ward, a result we consider
+honest to report exactly as computed rather than rounding up to "fully stable."
+
+## 7. Nature-Based Solutions Engine and the Ecological Plantability Filter
+
+Given a cell's HVI and its underlying indicators, `pipeline/06_nbs.py` fires one or
+more rule-based recommendations, each carrying a plain-language rationale and a
+citation. "High" and "low" thresholds are the 75th/25th percentile of that indicator
+**within the current run's cells**, not fixed absolute cutoffs. Several indicators
+(notably `elderly_pct`) have too narrow an observed range across Mumbai for an absolute
+threshold to be meaningful.
+
+| Condition | Recommendation | Citation |
+|---|---|---|
+| HVI ≥ p75, NDVI ≤ p25, cell is plantable | Native tree planting + green corridors | Bastin et al. 2019 |
+| HVI ≥ p75, NDVI ≤ p25, cell is **not** plantable | Cool roofs + reflective pavements + cooling centres | Veldman et al. 2019 |
+| impervious_pct ≥ p75 and within 500 m of mapped water/wetland | Rain gardens + water-sensitive urban design (WSUD) | Methodology proxy (no dedicated hydrology layer) |
+| pop_density_km2 ≥ p75 and NDVI ≤ p25 | Pocket parks | C40 Urban Cooling Toolbox |
+| elderly_pct ≥ p75 and hospital_dist_m ≥ p75 | Cooling centres, priority siting | Knowlton et al. 2014 |
+
+**The ecological plantability filter** is the headline design decision of this engine:
+a cell is only eligible for the tree-planting recommendation if it is *not* water,
+wetland, mangrove, or built-up (ESA WorldCover classes 50/80/90/95), *not* native
+grassland (WorldCover class 30, per Veldman et al. 2019's caution against afforesting
+grassland/savanna ecosystems), and has impervious cover below the 75th percentile
+(physical room to plant). A cell that clears the vulnerability bar but fails this
+ecological check is routed to the non-tree recommendation (cool roofs / reflective
+pavements / cooling centres) instead. The product is deliberately built to be able to
+say "this ward needs cooling, but not via tree planting" rather than defaulting to
+trees everywhere.
+
+**As of this run:** 337 of 541 cells (62%) were classified plantable. Across all 24
+wards, 81 ward-level recommendation rows fired: 24 rain-garden/WSUD, 18 cool-roof, 18
+pocket-park, 12 native-tree-planting, and 9 cooling-centre-priority recommendations.
+Every ward received at least one recommendation.
+
+## 8. Green Cover Change Classification
+
+`pipeline/09_ndvi_change.py` classifies each cell's NDVI delta between the current
+dry-season composite and an older dry-season baseline (`NDVI - NDVI_prev`, roughly a
+nine-year gap) as `gained` (delta > +0.05), `lost` (delta < −0.05), or `stable`
+(otherwise). The ±0.05 threshold is a deliberate, documented choice, chosen in the
+same spirit as the ±20% perturbation tolerance in Section 6, as "the size of change
+trusted as real signal rather than noise" for this dataset, not a value taken from a
+specific external paper. As of this run, the classification split 445 cells stable, 84
+gained, and 12 lost, across the 541-cell grid.
+
+## 9. Illustrative Cooling Coefficients (Simulator)
+
+A separate, clearly-labelled part of the product (`/simulate`,
+`frontend/src/lib/coefficients.ts`) lets a user estimate the illustrative cooling effect
+of a hypothetical intervention, using coefficients transferred from the cited
+literature rather than fit to Mumbai: canopy cooling follows Ziter et al. 2019
+(negligible effect below ~40% canopy cover, up to ~1.0°C of daytime cooling by 80%
+cover, non-linear and capped rather than extrapolated past the paper's own range);
+cool-roof/high-albedo cooling uses a conservative 0.6°C per +0.1 albedo headline figure
+with a 0.57-2.3°C per +0.1 range exposed as uncertainty (Santamouris 2014), with Li,
+Bou-Zeid & Oppenheimer (2014) cited as structural support for treating the relationship
+as linear; pocket-park cooling scales a 0.94°C park-cool-island ceiling (Bowler et al.
+2010) linearly by the share of ward area converted to park-like green space, an
+explicit simplifying assumption stated as such rather than presented as a result from
+the source paper. These three terms are summed independently, with no attempt to model
+interaction effects (e.g. double-counting trees that are also inside a park). This
+simulator is not part of the HVI computation itself; it is included in this report
+because it draws on the same citation discipline and the same cited coefficients
+appear in `docs/references.md`.
+
+## 10. Limitations
+
+Stated here in full, matching `docs/methodology.md` section 10:
+
+- **Land surface temperature is not air temperature.** `LST_C` is a satellite-derived
+  surface measurement; it correlates with but is not equivalent to the air temperature
+  a person actually experiences. The product's live-weather widget
+  (`frontend/src/lib/weather.ts`) exists specifically to make this distinction
+  tangible with a real, concurrently-fetched air-temperature reading.
+- **Cooling coefficients are transferred, not Mumbai-calibrated.** The Section 9
+  coefficients come from other cities' studies (Ziter et al. in eastern North America,
+  Santamouris's city-scale review, Li/Bou-Zeid/Oppenheimer's Baltimore-DC simulation,
+  Bowler et al.'s meta-analysis); no Mumbai-specific field validation of these
+  magnitudes has been performed.
+- **Slum-density and elderly layers are proxies.** `slum_pct` comes from mapped
+  slum-cluster boundaries (Datameet) rather than a household survey, and `elderly_pct`
+  comes from WorldPop's 2020 age-sex structure (the most recent year available for
+  India in that collection) rather than ward-level census data.
+- **The simulator (Section 9) is a first-order estimate**, explicitly not a validated
+  microclimate model, and is labelled as such in its own UI.
+- **The ecological plantability layer is coarse-resolution**, driven by ESA WorldCover
+  at its native ~10 m pixel size aggregated to 1 km cells, and by a single flood-risk
+  proxy (distance to mapped water/wetland) rather than a dedicated hydrology layer.
+- **PCA weights are a function of the current snapshot**, as noted in Section 5; they
+  are expected to be broadly stable given the Section 6 sensitivity results, but are
+  not literally fixed across every possible re-run of the pipeline.
+
+## 11. Reproducibility
+
+Every figure in this report was read from files this repository's own pipeline
+produced: `data/hvi_pca_log.json` (Section 5), `data/sensitivity.json` (Section 6),
+`data/nbs_recommendations.json` and `data/cells_hvi.geojson` (Section 7),
+`data/cells_ndvi_change.geojson` (Section 8). The full pipeline can be re-run end to
+end with `python pipeline/run_pipeline.py` (see `pipeline/README.md`), which will
+regenerate all of the above from the same source data and procedure described here.
+
+## 12. References
+
+| Use | Citation | DOI |
+|---|---|---|
+| HVI weighting method | Reid et al. 2009, *Environ. Health Perspect.* 117(11):1730-1736 | 10.1289/ehp.0900683 |
+| Local credibility, first South Asian HAP | Knowlton et al. 2014, *IJERPH* 11(4):3473-3492 | 10.3390/ijerph110403473 |
+| India-wide district HVI precedent | Azhar et al. 2017 (RAND India HVI), *IJERPH* 14(4):357 | 10.3390/ijerph14040357 |
+| Tree restoration potential | Bastin et al. 2019, *Science* 365(6448):76-79 | 10.1126/science.aax0848 |
+| Plantability filter (critique of afforestation-everywhere) | Veldman et al. 2019, *Science* 366(6463):eaay7976 | 10.1126/science.aay7976 |
+| Carbon-cycle critique companion | Friedlingstein et al. 2019, *Science* 366(6463):eaay8060 | 10.1126/science.aay8060 |
+| Regrowth critique companion | Lewis et al. 2019, *Science* 366(6463):eaaz0388 | 10.1126/science.aaz0388 |
+| Canopy → LST reduction coefficient | Ziter et al. 2019, *PNAS* 116(15):7575-7580 | 10.1073/pnas.1817561116 |
+| Cool-roof city-scale simulation | Li, Bou-Zeid & Oppenheimer 2014, *Environ. Res. Lett.* 9(5):055002 | 10.1088/1748-9326/9/5/055002 |
+| Albedo → peak-temperature coefficient | Santamouris 2014, *Solar Energy* 103:682-703 | 10.1016/j.solener.2012.07.003 |
+| Pocket-park cooling coefficient | Bowler et al. 2010, *Landscape and Urban Planning* 97:147-155 | 10.1016/j.landurbplan.2010.05.006 |
+
+DOIs above were verified against the publisher resolvers as documented in
+`docs/references.md`; this report does not re-verify them independently. For the
+complete citation table, including data-source access details not repeated here, see
+`docs/references.md`.
+
+---
+
+*This report mirrors and extends `docs/methodology.md`; where the two differ in level
+of detail, this document is the more complete one and `docs/methodology.md` should be
+treated as the shorter in-app summary of it. Prepared for issue #66. Not submitted to
+arXiv, SSRN, or any external venue; that step, if pursued, is a decision for the
+project maintainer and is outside what this PR does.*

--- a/docs/HVI-methodology-report.md
+++ b/docs/HVI-methodology-report.md
@@ -70,7 +70,13 @@ The study area is Mumbai, analyzed at 1 km grid-cell resolution and rolled up to
 city's 24 BMC administrative wards. The pipeline (`pipeline/01_grid.py`) builds this
 grid by clipping a fishnet to ward boundaries in a metric CRS (EPSG:32643, UTM zone
 43N) and assigning each cell to the ward containing its largest fragment. As of the
-data underlying this report, the grid contains 541 cells across all 24 wards.
+data underlying this report, that raw fishnet produces 547 cells across all 24 wards
+(`data/grid_1km.geojson`). A later consolidation step, `pipeline/04_zonal.py`, drops
+any cell missing one or more of the seven indicators in Section 4 before the indicators
+can be z-standardized; as of this run that drops 6 of the 547 cells (about 1%, well
+under the pipeline's own 15% sanity-check ceiling for data loss), leaving the 541-cell
+table (`data/cells.geojson`) that every subsequent stage, and every other cell count in
+this report, is computed from.
 
 | Layer | Source | Access | Note |
 |---|---|---|---|
@@ -152,8 +158,11 @@ PC1's loadings and therefore these weights. What is fixed, and cited, is the *pr
 all cells in the run (min mapped to 0, max to 100). Ward-level HVI is the unweighted
 mean of its member cells' scores, and ward rank is `HVI` sorted descending (rank 1 =
 most vulnerable). As of this run, the five highest-ranked wards are C, G/N, L, E, and
-F/S (HVI 73.6, 69.7, 65.8, 65.0, and 64.8 respectively), each driven primarily by
-`impervious_pct` except L, driven primarily by `LST_C`.
+F/S (HVI 73.6, 69.7, 65.8, 65.0, and 64.8 respectively). Reading each ward's largest
+per-factor contribution directly from `data/wards_hvi.geojson`: C, G/N, and E are each
+driven primarily by `impervious_pct` (contributions 0.292, 0.217, and 0.233
+respectively); L primarily by `LST_C` (0.209); and F/S primarily by `elderly_pct`
+(0.170), narrowly ahead of `impervious_pct` (0.140) for that one ward.
 
 **Explainability.** Per-cell, per-indicator contributions (`weight × signed z-score`)
 are stored alongside the score and shown as a ranked bar breakdown in the product.
@@ -175,15 +184,23 @@ by Kendall's tau (rank-correlation over all 24 wards) and by top-5 overlap (how 
 the baseline top-5 most-vulnerable wards remain in the perturbed top-5).
 
 **Results.** Mean Kendall tau across all 14 runs was 0.978 (1.0 = identical ranking),
-and mean top-5 overlap was 4.43 of 5. The top three wards by HVI (C, G/N, L) were
-unchanged in every one of the 14 perturbations. In 6 of the 14 runs the entire top-5
-set matched baseline exactly; in the remaining 8, exactly one ward (either the
-baseline's 4th- or 5th-ranked ward, F/S or E) was displaced by ward B, and overlap
-never fell below 4 of 5 in any run. No perturbation altered which ward ranked most
-vulnerable overall. We read this as the ward-priority ordering being stable under
-plausible weight disagreement at the top of the ranking, with some genuine sensitivity
-at the boundary between the 4th and 5th most-vulnerable ward, a result we consider
-honest to report exactly as computed rather than rounding up to "fully stable."
+and mean top-5 overlap was 4.43 of 5. Overlap was 5 of 5 (the entire top-5 set matched
+baseline exactly) in 6 of the 14 runs, and 4 of 5 in the other 8; it never fell below 4
+in any run. Reading `data/sensitivity.json`'s per-run rankings directly rather than
+summarizing from memory: only the top TWO wards by HVI, C and G/N, were unchanged in
+every one of the 14 perturbations. Ward L (baseline rank 3) dropped out of the top 5 in
+2 of the 14 runs (`elderly_pct` +20%, `slum_pct` -20%), ward E (baseline rank 4)
+dropped out in 2 runs (`hospital_dist_m` +20%, `impervious_pct` -20%), and ward F/S
+(baseline rank 5) dropped out in 4 runs (`LST_C` -20%, `NDVI` +20%,
+`pop_density_km2` -20%, `impervious_pct` +20%). In every one of these 8 runs, the ward
+dropped from the top 5 was replaced by exactly one ward, B, and never by any other
+ward. No perturbation altered which ward ranked most vulnerable overall: ward C is
+rank 1 in the baseline and in all 14 perturbed rankings. We read this as the top of the
+ranking (ranks 1-2) being fully robust to plausible weight disagreement, with
+increasing but still bounded sensitivity moving down through ranks 3-5, where ward B is
+the one consistent alternative that displaces the baseline's 3rd-5th-ranked wards under
+perturbation. This is a more qualified result than "top 5 is stable," and we consider
+reporting it exactly as computed more honest than rounding up.
 
 ## 7. Nature-Based Solutions Engine and the Ecological Plantability Filter
 

--- a/pipeline/00_gee_spike.py
+++ b/pipeline/00_gee_spike.py
@@ -17,16 +17,15 @@ Run:
     python 00_gee_spike.py
 """
 
-import os
 import sys
 import urllib.request
 
 import ee
 
-from _gee_auth import init_ee
+from _gee_auth import init_ee, resolve_project
 
 # ---------------------------------------------------------------- config ----
-GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mumbai")
+GEE_PROJECT = resolve_project()
 
 # Small test bbox: central Mumbai (roughly Dadar/Sion belt). One ward-sized area.
 TEST_BBOX = [72.83, 19.00, 72.92, 19.08]  # [west, south, east, north]

--- a/pipeline/00_gee_spike.py
+++ b/pipeline/00_gee_spike.py
@@ -23,6 +23,8 @@ import urllib.request
 
 import ee
 
+from _gee_auth import init_ee
+
 # ---------------------------------------------------------------- config ----
 GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mumbai")
 
@@ -48,7 +50,7 @@ def mask_l2_clouds(img: ee.Image) -> ee.Image:
 
 
 def main() -> int:
-    ee.Initialize(project=GEE_PROJECT)
+    init_ee(GEE_PROJECT)
     print(f"[ok] Earth Engine initialized (project={GEE_PROJECT})")
 
     region = ee.Geometry.Rectangle(TEST_BBOX)

--- a/pipeline/02_gee_layers.py
+++ b/pipeline/02_gee_layers.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import ee
 
+from _gee_auth import init_ee
+
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 GRID_PATH = DATA_DIR / "grid_1km.geojson"
 OUT_PATH = DATA_DIR / "grid_1km_gee.geojson"
@@ -77,7 +79,7 @@ def main() -> int:
         print(f"[FAIL] {GRID_PATH} not found — run 01_grid.py first.")
         return 1
 
-    ee.Initialize(project=GEE_PROJECT)
+    init_ee(GEE_PROJECT)
     print(f"[ok] Earth Engine initialized (project={GEE_PROJECT})")
 
     grid_fc = load_grid_fc(GRID_PATH)

--- a/pipeline/02_gee_layers.py
+++ b/pipeline/02_gee_layers.py
@@ -14,19 +14,18 @@ Run:
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 
 import ee
 
-from _gee_auth import init_ee
+from _gee_auth import init_ee, resolve_project
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 GRID_PATH = DATA_DIR / "grid_1km.geojson"
 OUT_PATH = DATA_DIR / "grid_1km_gee.geojson"
 
-GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mum")
+GEE_PROJECT = resolve_project()
 
 # Same dry-season window validated by the Day-0 spike (00_gee_spike.py).
 CURR_START, CURR_END = "2025-11-01", "2026-02-28"

--- a/pipeline/03_vectors.py
+++ b/pipeline/03_vectors.py
@@ -26,6 +26,8 @@ import ee
 import geopandas as gpd
 import osmnx as ox
 
+from _gee_auth import init_ee
+
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 GRID_PATH = DATA_DIR / "grid_1km_gee.geojson"
 WARDS_PATH = DATA_DIR / "bmc_wards.geojson"
@@ -140,7 +142,7 @@ def main() -> int:
     grid_gdf = gpd.read_file(GRID_PATH)
     print(f"[ok] loaded {len(grid_gdf)} grid cells")
 
-    ee.Initialize(project=GEE_PROJECT)
+    init_ee(GEE_PROJECT)
     print(f"[ok] Earth Engine initialized (project={GEE_PROJECT})")
     grid_fc = load_grid_fc(GRID_PATH)
 

--- a/pipeline/03_vectors.py
+++ b/pipeline/03_vectors.py
@@ -18,7 +18,6 @@ Run:
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -26,7 +25,7 @@ import ee
 import geopandas as gpd
 import osmnx as ox
 
-from _gee_auth import init_ee
+from _gee_auth import init_ee, resolve_project
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 GRID_PATH = DATA_DIR / "grid_1km_gee.geojson"
@@ -34,7 +33,7 @@ WARDS_PATH = DATA_DIR / "bmc_wards.geojson"
 SLUMS_PATH = DATA_DIR / "slumClusters.geojson"
 OUT_PATH = DATA_DIR / "grid_1km_vectors.geojson"
 
-GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mum")
+GEE_PROJECT = resolve_project()
 UTM_CRS = "EPSG:32643"
 WGS84 = "EPSG:4326"
 

--- a/pipeline/05_hvi.py
+++ b/pipeline/05_hvi.py
@@ -17,13 +17,14 @@ Run:
 """
 
 import json
-import shutil
 import sys
 from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
 from sklearn.decomposition import PCA
+
+from _publish import publish
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -136,10 +137,6 @@ def main() -> int:
     wards_out.to_file(OUT_WARDS_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(wards_out)} wards with ranked HVI -> {OUT_WARDS_PATH}")
 
-    OUT_WARDS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(OUT_WARDS_PATH, OUT_WARDS_PUBLIC_PATH)
-    print(f"[ok] copied -> {OUT_WARDS_PUBLIC_PATH}")
-
     OUT_METHOD_PATH.write_text(json.dumps({
         "explained_variance_pc1": explained_var_1,
         "loadings_pc1": dict(zip(cols, loadings_1.tolist())),
@@ -151,6 +148,11 @@ def main() -> int:
     print(f"[ok] wrote PCA log -> {OUT_METHOD_PATH}")
 
     # ------------------------------------------------------- sanity checks --
+    # Runs BEFORE the frontend/public copy below, on purpose: data/ is always written
+    # (it's the pipeline's own working state, and the demo-safe-fallback snapshot logic
+    # in 07_load.py already treats data/ as the thing to inspect on a bad run), but the
+    # live site must not start serving a run that failed its own sanity check just
+    # because the copy happened to run first.
     ok = True
     if not (0 <= gdf["HVI"].min() and gdf["HVI"].max() <= 100.0001):
         print(f"[WARN] HVI range {gdf['HVI'].min()}-{gdf['HVI'].max()} outside 0-100")
@@ -160,6 +162,13 @@ def main() -> int:
         ok = False
     print("\nTop 5 most vulnerable wards:")
     print(ward_hvi[["rank", "ward_id", "HVI", "n_cells"]].head(5).to_string(index=False))
+
+    if ok:
+        publish(OUT_WARDS_PATH, OUT_WARDS_PUBLIC_PATH)
+    else:
+        print(f"[WARN] sanity check failed -- NOT copying to {OUT_WARDS_PUBLIC_PATH}; "
+              "the live site keeps serving its previous wards_hvi.geojson")
+
     print("\nGO" if ok else "\nCHECK WARNINGS")
     return 0 if ok else 2
 

--- a/pipeline/05_hvi.py
+++ b/pipeline/05_hvi.py
@@ -17,6 +17,7 @@ Run:
 """
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -24,11 +25,18 @@ import geopandas as gpd
 import numpy as np
 from sklearn.decomposition import PCA
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
 IN_PATH = DATA_DIR / "cells.geojson"
 OUT_CELLS_PATH = DATA_DIR / "cells_hvi.geojson"
 OUT_WARDS_PATH = DATA_DIR / "wards_hvi.geojson"
 OUT_METHOD_PATH = DATA_DIR / "hvi_pca_log.json"
+# wards_hvi.geojson is what the frontend actually reads at request time (server-side
+# in page.tsx via fs, client-side via fetch in useWardData.ts and WardChoropleth.tsx),
+# so it has to land in frontend/public/, not just data/, on every refresh -- the same
+# "write to data/ AND frontend/public/" pattern 10_ward_profile.py, 11_hero_city.py and
+# 12_hero_region.py already use for their own outputs.
+OUT_WARDS_PUBLIC_PATH = ROOT / "frontend" / "public" / "wards_hvi.geojson"
 
 # direction: +1 means "higher raw value = more vulnerable", -1 = inverted (methodology.md §3)
 INDICATORS = {
@@ -127,6 +135,10 @@ def main() -> int:
     wards_out = wards.merge(ward_hvi, on="ward_id", how="left")
     wards_out.to_file(OUT_WARDS_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(wards_out)} wards with ranked HVI -> {OUT_WARDS_PATH}")
+
+    OUT_WARDS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OUT_WARDS_PATH, OUT_WARDS_PUBLIC_PATH)
+    print(f"[ok] copied -> {OUT_WARDS_PUBLIC_PATH}")
 
     OUT_METHOD_PATH.write_text(json.dumps({
         "explained_variance_pc1": explained_var_1,

--- a/pipeline/06_nbs.py
+++ b/pipeline/06_nbs.py
@@ -29,6 +29,7 @@ Run:
 
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -37,10 +38,17 @@ import geopandas as gpd
 
 from _gee_auth import init_ee
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
 IN_PATH = DATA_DIR / "cells_hvi.geojson"
 OUT_CELLS_PATH = DATA_DIR / "cells_nbs.geojson"
 OUT_WARD_RECS_PATH = DATA_DIR / "nbs_recommendations.json"
+# Both files are fetched directly by the browser (WardChoropleth.tsx's plantability
+# layer reads cells_nbs.geojson; useWardData.ts reads nbs_recommendations.json for the
+# dashboard's per-ward NBS list), so both need a frontend/public/ copy on every
+# refresh, same as 10_ward_profile.py/11_hero_city.py/12_hero_region.py already do.
+OUT_CELLS_PUBLIC_PATH = ROOT / "frontend" / "public" / "cells_nbs.geojson"
+OUT_WARD_RECS_PUBLIC_PATH = ROOT / "frontend" / "public" / "nbs_recommendations.json"
 
 GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mum")
 ZONAL_SCALE = 10  # WorldCover native resolution
@@ -171,6 +179,10 @@ def main() -> int:
     gdf.to_file(OUT_CELLS_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(gdf)} cells with NBS flags -> {OUT_CELLS_PATH}")
 
+    OUT_CELLS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OUT_CELLS_PATH, OUT_CELLS_PUBLIC_PATH)
+    print(f"[ok] copied -> {OUT_CELLS_PUBLIC_PATH}")
+
     # ------------------------------------------------- ward-level rollup --
     ward_recs = {}
     for r in all_recs:
@@ -189,6 +201,10 @@ def main() -> int:
     ward_recs_list = sorted(ward_recs.values(), key=lambda r: (r["ward_id"], r["priority"]))
     OUT_WARD_RECS_PATH.write_text(json.dumps(ward_recs_list, indent=2), encoding="utf-8")
     print(f"[ok] wrote {len(ward_recs_list)} ward-level recommendation rows -> {OUT_WARD_RECS_PATH}")
+
+    OUT_WARD_RECS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OUT_WARD_RECS_PATH, OUT_WARD_RECS_PUBLIC_PATH)
+    print(f"[ok] copied -> {OUT_WARD_RECS_PUBLIC_PATH}")
 
     # ------------------------------------------------------- sanity checks --
     ok = True

--- a/pipeline/06_nbs.py
+++ b/pipeline/06_nbs.py
@@ -35,6 +35,8 @@ from pathlib import Path
 import ee
 import geopandas as gpd
 
+from _gee_auth import init_ee
+
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 IN_PATH = DATA_DIR / "cells_hvi.geojson"
 OUT_CELLS_PATH = DATA_DIR / "cells_nbs.geojson"
@@ -55,7 +57,7 @@ def load_grid_fc(gdf: gpd.GeoDataFrame) -> ee.FeatureCollection:
 
 
 def pull_landcover_and_flood_proxy(gdf: gpd.GeoDataFrame) -> dict:
-    ee.Initialize(project=GEE_PROJECT)
+    init_ee(GEE_PROJECT)
     grid_fc = load_grid_fc(gdf)
     worldcover = ee.ImageCollection("ESA/WorldCover/v200").first()
 

--- a/pipeline/06_nbs.py
+++ b/pipeline/06_nbs.py
@@ -28,15 +28,14 @@ Run:
 """
 
 import json
-import os
-import shutil
 import sys
 from pathlib import Path
 
 import ee
 import geopandas as gpd
 
-from _gee_auth import init_ee
+from _gee_auth import init_ee, resolve_project
+from _publish import publish
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -50,7 +49,7 @@ OUT_WARD_RECS_PATH = DATA_DIR / "nbs_recommendations.json"
 OUT_CELLS_PUBLIC_PATH = ROOT / "frontend" / "public" / "cells_nbs.geojson"
 OUT_WARD_RECS_PUBLIC_PATH = ROOT / "frontend" / "public" / "nbs_recommendations.json"
 
-GEE_PROJECT = os.environ.get("GEE_PROJECT", "ucip-mum")
+GEE_PROJECT = resolve_project()
 ZONAL_SCALE = 10  # WorldCover native resolution
 
 WORLDCOVER_GRASSLAND = 30
@@ -179,10 +178,6 @@ def main() -> int:
     gdf.to_file(OUT_CELLS_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(gdf)} cells with NBS flags -> {OUT_CELLS_PATH}")
 
-    OUT_CELLS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(OUT_CELLS_PATH, OUT_CELLS_PUBLIC_PATH)
-    print(f"[ok] copied -> {OUT_CELLS_PUBLIC_PATH}")
-
     # ------------------------------------------------- ward-level rollup --
     ward_recs = {}
     for r in all_recs:
@@ -202,11 +197,11 @@ def main() -> int:
     OUT_WARD_RECS_PATH.write_text(json.dumps(ward_recs_list, indent=2), encoding="utf-8")
     print(f"[ok] wrote {len(ward_recs_list)} ward-level recommendation rows -> {OUT_WARD_RECS_PATH}")
 
-    OUT_WARD_RECS_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(OUT_WARD_RECS_PATH, OUT_WARD_RECS_PUBLIC_PATH)
-    print(f"[ok] copied -> {OUT_WARD_RECS_PUBLIC_PATH}")
-
     # ------------------------------------------------------- sanity checks --
+    # Runs BEFORE the frontend/public copies below, on purpose -- see 05_hvi.py's
+    # matching comment. Both files are gated on the same "ok" so a run that fails this
+    # check publishes neither a stale-relative-to-cells_nbs recommendations file nor a
+    # stale-relative-to-recommendations cells file; they stay a matched pair.
     ok = True
     wards_with_recs = {r["ward_id"] for r in all_recs}
     if len(wards_with_recs) < 15:
@@ -215,6 +210,14 @@ def main() -> int:
     if n_rejected_grassland == 0:
         print("[WARN] plantability filter never rejected a grassland cell — check WorldCover class mapping")
     print(f"\n{len(all_recs)} recommendation rows fired across {len(wards_with_recs)} wards")
+
+    if ok:
+        publish(OUT_CELLS_PATH, OUT_CELLS_PUBLIC_PATH)
+        publish(OUT_WARD_RECS_PATH, OUT_WARD_RECS_PUBLIC_PATH)
+    else:
+        print(f"[WARN] sanity check failed -- NOT copying to {OUT_CELLS_PUBLIC_PATH} or "
+              f"{OUT_WARD_RECS_PUBLIC_PATH}; the live site keeps serving its previous NBS output")
+
     print("GO" if ok else "CHECK WARNINGS")
     return 0 if ok else 2
 

--- a/pipeline/08_sensitivity.py
+++ b/pipeline/08_sensitivity.py
@@ -18,7 +18,6 @@ Run:
 """
 
 import json
-import shutil
 import sys
 from pathlib import Path
 
@@ -29,6 +28,8 @@ from scipy.stats import kendalltau
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+
+from _publish import publish
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -144,14 +145,19 @@ def main() -> int:
     fig.savefig(OUT_CHART_PATH, dpi=150)
     print(f"[ok] wrote chart -> {OUT_CHART_PATH}")
 
-    OUT_CHART_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(OUT_CHART_PATH, OUT_CHART_PUBLIC_PATH)
-    print(f"[ok] copied -> {OUT_CHART_PUBLIC_PATH}")
-
     # ------------------------------------------------------- sanity checks --
+    # Runs BEFORE the frontend/public copy below, on purpose -- see 05_hvi.py's
+    # matching comment.
     ok = mean_tau > 0.7 and mean_overlap >= TOP_N - 1
     print(f"\nmean Kendall tau={mean_tau:.3f}, mean top-{TOP_N} overlap={mean_overlap:.1f}/{TOP_N}, "
           f"all runs fully stable={all_stable}")
+
+    if ok:
+        publish(OUT_CHART_PATH, OUT_CHART_PUBLIC_PATH)
+    else:
+        print(f"[WARN] sanity check failed -- NOT copying to {OUT_CHART_PUBLIC_PATH}; "
+              "the live site keeps serving its previous sensitivity_chart.png")
+
     print("GO: ranking stable under perturbation." if ok else "CHECK: ranking sensitive to some weight(s) — inspect sensitivity.json.")
     return 0 if ok else 2
 

--- a/pipeline/08_sensitivity.py
+++ b/pipeline/08_sensitivity.py
@@ -18,6 +18,7 @@ Run:
 """
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -29,11 +30,19 @@ from scipy.stats import kendalltau
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
 CELLS_PATH = DATA_DIR / "cells.geojson"
 PCA_LOG_PATH = DATA_DIR / "hvi_pca_log.json"
 OUT_JSON_PATH = DATA_DIR / "sensitivity.json"
 OUT_CHART_PATH = DATA_DIR / "sensitivity_chart.png"
+# sensitivity.json itself is read server-side straight out of data/ (see
+# frontend/src/app/methodology/page.tsx's readJson, which resolves "../data/..." from
+# frontend/), so it needs no copy. The chart PNG is different: methodology/page.tsx
+# renders it as a plain <img src="/sensitivity_chart.png">, a browser-fetched static
+# asset, so it has to land in frontend/public/ on every refresh like the other
+# browser-fetched outputs.
+OUT_CHART_PUBLIC_PATH = ROOT / "frontend" / "public" / "sensitivity_chart.png"
 
 INDICATORS_DIRECTION = {
     "LST_C": 1, "NDVI": -1, "pop_density_km2": 1, "elderly_pct": 1,
@@ -134,6 +143,10 @@ def main() -> int:
     plt.tight_layout()
     fig.savefig(OUT_CHART_PATH, dpi=150)
     print(f"[ok] wrote chart -> {OUT_CHART_PATH}")
+
+    OUT_CHART_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OUT_CHART_PATH, OUT_CHART_PUBLIC_PATH)
+    print(f"[ok] copied -> {OUT_CHART_PUBLIC_PATH}")
 
     # ------------------------------------------------------- sanity checks --
     ok = mean_tau > 0.7 and mean_overlap >= TOP_N - 1

--- a/pipeline/09_ndvi_change.py
+++ b/pipeline/09_ndvi_change.py
@@ -16,15 +16,21 @@ Run:
     python 09_ndvi_change.py
 """
 
+import shutil
 import sys
 from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
 IN_PATH = DATA_DIR / "cells_hvi.geojson"
 OUT_PATH = DATA_DIR / "cells_ndvi_change.geojson"
+# WardChoropleth.tsx's green-cover-change layer fetches this straight from the
+# browser, so it needs a frontend/public/ copy on every refresh, same as
+# 10_ward_profile.py/11_hero_city.py/12_hero_region.py already do for theirs.
+OUT_PUBLIC_PATH = ROOT / "frontend" / "public" / "cells_ndvi_change.geojson"
 
 GAIN_THRESHOLD = 0.05
 LOSS_THRESHOLD = -0.05
@@ -67,6 +73,10 @@ def main() -> int:
     out = gdf[out_cols]
     out.to_file(OUT_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(out)} cells with NDVI-change classification -> {OUT_PATH}")
+
+    OUT_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(OUT_PATH, OUT_PUBLIC_PATH)
+    print(f"[ok] copied -> {OUT_PUBLIC_PATH}")
 
     # ------------------------------------------------------- sanity checks --
     counts = out["change_class"].value_counts().to_dict()

--- a/pipeline/09_ndvi_change.py
+++ b/pipeline/09_ndvi_change.py
@@ -16,12 +16,13 @@ Run:
     python 09_ndvi_change.py
 """
 
-import shutil
 import sys
 from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
+
+from _publish import publish
 
 ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT / "data"
@@ -74,14 +75,19 @@ def main() -> int:
     out.to_file(OUT_PATH, driver="GeoJSON")
     print(f"[ok] wrote {len(out)} cells with NDVI-change classification -> {OUT_PATH}")
 
-    OUT_PUBLIC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(OUT_PATH, OUT_PUBLIC_PATH)
-    print(f"[ok] copied -> {OUT_PUBLIC_PATH}")
-
     # ------------------------------------------------------- sanity checks --
+    # Runs BEFORE the frontend/public copy below, on purpose -- see 05_hvi.py's
+    # matching comment.
     counts = out["change_class"].value_counts().to_dict()
     print(f"\nclass counts: {counts}")
     ok = counts.get("unknown", 0) < 0.1 * len(out)
+
+    if ok:
+        publish(OUT_PATH, OUT_PUBLIC_PATH)
+    else:
+        print(f"[WARN] sanity check failed -- NOT copying to {OUT_PUBLIC_PATH}; "
+              "the live site keeps serving its previous cells_ndvi_change.geojson")
+
     print("GO" if ok else "CHECK WARNINGS: too many 'unknown' cells")
     return 0 if ok else 2
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,0 +1,90 @@
+# Pipeline
+
+Thirteen numbered stages (`00_gee_spike.py` through `12_hero_region.py`) that turn raw
+satellite imagery, WorldPop demographics, and OSM/Datameet vector data into the Heat
+Vulnerability Index, the NBS recommendations, and every JSON/GeoJSON file the frontend
+reads. Each script is documented in its own docstring and is still runnable standalone;
+this page covers running them as one chain, and when that chain should actually run.
+
+## Running a refresh
+
+```bash
+cd pipeline
+python -m venv .venv
+.venv\Scripts\activate      # .venv/bin/activate on macOS/Linux
+pip install -r requirements.txt
+earthengine authenticate    # once, needs your own Google Earth Engine account
+cp ../.env.example ../.env.local   # fill in Supabase keys if you want the DB upsert too
+
+python run_pipeline.py
+```
+
+`run_pipeline.py` (issue #56) runs stages `01` through `12` in dependency order, stops at
+the first hard failure, and writes a run log to `data/pipeline_run_log.json`. Useful
+flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Print the execution plan, run nothing. |
+| `--from 05` | Resume the chain starting at stage `05` (after fixing a failure). |
+| `--only 08,09` | Run just the listed stages. |
+| `--include-spike` | Also run `00_gee_spike.py` first (excluded by default, see below). |
+| `--keep-going` | Don't stop the chain on a hard failure. |
+
+`00_gee_spike.py` is a one-time development go/no-go gate, not a stage of a real
+refresh: it queries a small fixed test bbox to sanity-check GEE connectivity and writes
+nothing any later stage reads. It stays in the repo and in `run_pipeline.py`'s stage
+list (so `--include-spike` can still run it, e.g. to smoke-test credentials in CI) but
+is excluded from a plain `python run_pipeline.py`.
+
+A stage script's exit code means: `0` clean pass, `2` ran but a sanity check flagged
+"CHECK WARNINGS" (non-fatal, e.g. the PCA fallback triggering), `1` hard failure. The
+runner stops the chain on `1` and continues past `2`.
+
+## Refresh cadence (issue #57)
+
+**Every stage below runs on a monthly cadence, not daily, because the data underneath
+it does not change daily.**
+
+| Stage | Cadence | Why |
+|-------|---------|-----|
+| `01_grid.py` | Monthly | BMC ward boundaries are static; only changes if `data/bmc_wards.geojson` is re-sourced. |
+| `02_gee_layers.py` | Monthly | Landsat 8/9 dry-season **composite** (`00_gee_spike.py`'s validated recipe), a multi-week median composite by construction, not a daily reading. |
+| `03_vectors.py` | Monthly | WorldPop's age-sex layer is pinned to a single annual vintage (`WORLDPOP_YEAR = "2020"`, see the script); OSM hospitals and slum-cluster boundaries change on the order of months, not days. |
+| `04_zonal.py` | Monthly | Pure consolidation of the two stages above; has nothing new to compute between their refreshes. |
+| `05_hvi.py` | Monthly | Deterministic function of `04`'s output; the PCA weights themselves are also expected to be stable run-to-run (see `docs/HVI-methodology-report.md` section 6, the sensitivity analysis). |
+| `06_nbs.py` | Monthly | Its GEE call is ESA WorldCover, an annual-cadence land-cover product. |
+| `07_load.py` | Monthly | Terminal upsert/snapshot step of the same refresh; runs once per chain, immediately after the stage that changed. |
+| `08_sensitivity.py` | Monthly | Cheap function of `05`'s weights; nothing to recompute until `05` changes. |
+| `09_ndvi_change.py` | Monthly | Function of `02`'s two NDVI composites (current vs. a ~9-year baseline); does not move month to month. |
+| `10_ward_profile.py` | Monthly | Rolls up `05`/`06` output; changes only when they do. |
+| `11_hero_city.py` | Monthly | Geometry + HVI/rank read from `05`; changes only when boundaries or HVI change. |
+| `12_hero_region.py` | Monthly | Natural Earth coastline, effectively static; cached to `data/cache/` after the first fetch. |
+
+Running this chain more often than monthly would re-fetch the same underlying
+satellite/demographic snapshot and re-derive the same numbers, at real GEE-quota cost,
+for a "last updated" timestamp with no real signal behind it: cosmetic freshness, not
+actual freshness. A monthly cron (`.github/workflows/pipeline-refresh.yml`, issue #58)
+matches the data's real cadence.
+
+**The one genuinely fast-changing number in the product, live air temperature, is
+intentionally not a pipeline stage at all.** `frontend/src/lib/weather.ts` fetches it
+client-side from Open-Meteo on every page load: no server, no cron, no committed
+snapshot, no staleness possible. That pattern (fetch live at request time, show an
+honest "unavailable" state on failure, never fabricate or cache a stale number) is the
+template for any future value that is actually fast-changing: extend `weather.ts`'s
+approach for it, rather than adding another monthly-refreshed pipeline stage and
+labeling it "daily" for effect.
+
+## Change diffing (issue #61)
+
+`diff_snapshots.py` compares two runs' worth of pipeline output (a "before" directory
+and an "after" directory, each holding `wards_hvi.geojson`, `nbs_recommendations.json`,
+and `cells_ndvi_change.geojson`) and reports, per ward: HVI rank shifts, NBS
+recommendations added/removed, and green-cover classification flips. It is a plain
+diff over pipeline artifacts, with no notion of user accounts or saved wards. See the
+script's own docstring and the PR description for what is and is not in scope.
+
+```bash
+python diff_snapshots.py --old-dir /path/to/previous/data --new-dir ../data --out ../data/pipeline_diff.json
+```

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -74,6 +74,17 @@ hand-copied into `frontend/public/` at that one point in time, indefinitely. All
 now copy their own output the same way `10`-`12` already did, so this can't recur
 silently for any stage added later either, as long as it follows the same pattern.
 
+**The copy runs AFTER each stage's own sanity check, and only if it passes.** `05`,
+`06`, `08`, and `09` each already had an end-of-run sanity check (HVI range and ward
+count, recommendation coverage, weight-perturbation stability, NDVI-unknown rate) that
+flags a bad run with a `[WARN]`/exit-code-2 but doesn't stop `run_pipeline.py`'s chain.
+A stage that produces genuinely bad data (fewer than 24 wards, unstable ranking, too
+many "unknown" NDVI cells) writes that bad data to `data/` as always, but its
+`frontend/public/` copy is skipped, with an explicit `[WARN]` saying so. The live site
+keeps serving its previous (last-known-good) file instead of a broken run, with no
+manual rollback needed. `pipeline/_publish.py`'s `publish(src, dest)` is the one place
+this copy actually happens, called from each stage's `if ok:` branch.
+
 ## Refresh cadence (issue #57)
 
 **Every stage below runs on a monthly cadence, not daily, because the data underneath

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -41,6 +41,39 @@ A stage script's exit code means: `0` clean pass, `2` ran but a sanity check fla
 "CHECK WARNINGS" (non-fatal, e.g. the PCA fallback triggering), `1` hard failure. The
 runner stops the chain on `1` and continues past `2`.
 
+## Frontend sync
+
+A refresh is only real if the live site actually serves it. The deployed frontend
+reads its data from `frontend/public/`, not from `data/` directly (see
+`frontend/src/lib/useWardData.ts`, `frontend/src/app/components/WardChoropleth.tsx`,
+and `frontend/src/app/page.tsx`), so every stage whose output the browser fetches at
+runtime writes to both places in the same run, not just `data/`:
+
+| Stage | Writes to `data/` | Also copies to `frontend/public/` |
+|-------|--------------------|------------------------------------|
+| `05_hvi.py` | `wards_hvi.geojson` | yes |
+| `06_nbs.py` | `cells_nbs.geojson`, `nbs_recommendations.json` | yes, both |
+| `08_sensitivity.py` | `sensitivity_chart.png` | yes |
+| `09_ndvi_change.py` | `cells_ndvi_change.geojson` | yes |
+| `10_ward_profile.py` | `ward_profiles.json` | yes (already did this before #56) |
+| `11_hero_city.py` | `hero_city.json` | yes (already did this before #56) |
+| `12_hero_region.py` | `hero_region.json` | yes (already did this before #56) |
+
+`sensitivity.json` and `hvi_pca_log.json` are the two exceptions: the methodology page
+(`frontend/src/app/methodology/page.tsx`) reads them server-side straight out of
+`../data/`, so they need no `frontend/public/` copy at all. `sensitivity_chart.png` is
+different from `sensitivity.json` even though both come from `08_sensitivity.py`: the
+chart is rendered as a plain `<img src="/sensitivity_chart.png">`, a browser-fetched
+static asset, so it does need the copy.
+
+Before this, only `10`-`12` copied their own output to `frontend/public/`; `05`, `06`,
+`08`, and `09`'s outputs were kept in sync by a one-time hand copy when the repo was
+first built, not by anything a refresh would repeat. A pipeline run would have quietly
+kept writing correct data to `data/` while the live site kept serving whatever was
+hand-copied into `frontend/public/` at that one point in time, indefinitely. All four
+now copy their own output the same way `10`-`12` already did, so this can't recur
+silently for any stage added later either, as long as it follows the same pattern.
+
 ## Refresh cadence (issue #57)
 
 **Every stage below runs on a monthly cadence, not daily, because the data underneath

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -118,6 +118,12 @@ recommendations added/removed, and green-cover classification flips. It is a pla
 diff over pipeline artifacts, with no notion of user accounts or saved wards. See the
 script's own docstring and the PR description for what is and is not in scope.
 
+Each of the three categories is only diffed if its own file existed in the "before"
+directory (`had_rank_baseline`/`had_nbs_baseline`/`had_green_cover_baseline` in the
+output), independently of the other two. A partial "before" directory, e.g. an
+interrupted first refresh, reports the categories it has no baseline for as not-diffed
+rather than as a false wall of changes for every ward.
+
 ```bash
 python diff_snapshots.py --old-dir /path/to/previous/data --new-dir ../data --out ../data/pipeline_diff.json
 ```

--- a/pipeline/_gee_auth.py
+++ b/pipeline/_gee_auth.py
@@ -12,19 +12,28 @@ Why this exists:
     account is configured, behavior is byte-for-byte what it was before this module
     existed.
 
-Service-account credentials, when present, are read from one of:
+Service-account credentials, when present, are read from one of these two
+PIPELINE-SPECIFIC variables:
     GEE_SERVICE_ACCOUNT_JSON       the full key JSON as a string (e.g. a GitHub secret)
-    GOOGLE_APPLICATION_CREDENTIALS a path to a key JSON file on disk
+    GEE_SERVICE_ACCOUNT_KEY_FILE   a path to a key JSON file on disk (for local testing)
 
-Neither is set in this fork/branch and no live GEE credentials were used to test this
-path, see the PR description for what remains unverified.
+Deliberately NOT read: the ambient `GOOGLE_APPLICATION_CREDENTIALS` variable that
+generic Google Cloud tooling (gcloud, other GCP client libraries) commonly sets. A
+developer who has that exported for unrelated work would otherwise be silently
+redirected off their working `earthengine authenticate` session into a service-account
+branch that most likely has no Earth Engine access at all, producing a confusing
+failure with nothing to do with what they actually touched. Requiring one of this
+module's own, unambiguous variable names means the service-account path only ever
+activates when someone deliberately set it up for this pipeline.
+
+Neither variable is set in this fork/branch and no live GEE credentials were used to
+test this path; see the PR description for what remains unverified.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import tempfile
 
 import ee
 
@@ -33,27 +42,21 @@ def init_ee(project: str) -> None:
     """Initialize Earth Engine, using a service account if one is configured.
 
     Falls back to the pre-existing `ee.Initialize(project=project)` behavior (relies on
-    locally persisted `earthengine authenticate` credentials) when no service account
-    environment variable is set, so this is a strict superset of the previous behavior.
+    locally persisted `earthengine authenticate` credentials) when neither service
+    account variable is set, so this is a strict superset of the previous behavior.
     """
     key_json = os.environ.get("GEE_SERVICE_ACCOUNT_JSON")
-    key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    key_path = os.environ.get("GEE_SERVICE_ACCOUNT_KEY_FILE")
 
     if key_json:
         info = json.loads(key_json)
         email = info.get("client_email")
         if not email:
             raise ValueError("GEE_SERVICE_ACCOUNT_JSON is missing 'client_email'")
-        # ee.ServiceAccountCredentials wants a path, not inline JSON, so spill the
-        # secret to a private temp file for the lifetime of this process only.
-        fd, tmp_path = tempfile.mkstemp(prefix="gee-key-", suffix=".json")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(key_json)
-            credentials = ee.ServiceAccountCredentials(email, tmp_path)
-            ee.Initialize(credentials, project=project)
-        finally:
-            os.remove(tmp_path)
+        # key_data takes the JSON inline; no need to spill the secret to a temp file
+        # on disk just to hand ee.ServiceAccountCredentials a path to read it back from.
+        credentials = ee.ServiceAccountCredentials(email, key_data=key_json)
+        ee.Initialize(credentials, project=project)
         return
 
     if key_path:
@@ -62,7 +65,7 @@ def init_ee(project: str) -> None:
         email = info.get("client_email")
         if not email:
             raise ValueError(f"{key_path} is missing 'client_email'")
-        credentials = ee.ServiceAccountCredentials(email, key_path)
+        credentials = ee.ServiceAccountCredentials(email, key_file=key_path)
         ee.Initialize(credentials, project=project)
         return
 

--- a/pipeline/_gee_auth.py
+++ b/pipeline/_gee_auth.py
@@ -28,6 +28,19 @@ activates when someone deliberately set it up for this pipeline.
 
 Neither variable is set in this fork/branch and no live GEE credentials were used to
 test this path; see the PR description for what remains unverified.
+
+Project-id resolution is also centralized here (resolve_project()) rather than left to
+each stage's own `os.environ.get("GEE_PROJECT", "<default>")` line: before this module
+existed, that line was copy-pasted into 00, 02, 03, and 06 with two different literal
+defaults ("ucip-mumbai" in 00, matching .env.example; "ucip-mum", missing the second
+syllable, in 02/03/06) that nobody had ever needed to reconcile, since 00 is a
+standalone smoke test that never runs in the same process as the others. Now that
+run_pipeline.py chains all of them in one CI job, and pipeline-refresh.yml's
+GEE_PROJECT resolution step supports leaving the secret unset entirely (issue #58),
+that drift became load-bearing: a run with no GEE_PROJECT secret configured would
+authenticate stage 00 against "ucip-mumbai" and stages 02/03/06 against "ucip-mum" in
+the same CI run. One shared resolve_project() means there is only one default left to
+get right.
 """
 
 from __future__ import annotations
@@ -37,14 +50,33 @@ import os
 
 import ee
 
+# The project id every stage falls back to when GEE_PROJECT isn't set in the
+# environment. Matches .env.example's documented GEE_PROJECT=ucip-mumbai.
+DEFAULT_PROJECT = "ucip-mumbai"
 
-def init_ee(project: str) -> None:
+
+def resolve_project() -> str:
+    """The GEE project id to use: GEE_PROJECT from the environment if set, else
+    DEFAULT_PROJECT. The single place this lookup happens, so every GEE-calling stage
+    resolves to the same project by construction instead of by each stage's own
+    copy-pasted os.environ.get(..., "<default>") agreeing (or not) with the others.
+    """
+    return os.environ.get("GEE_PROJECT", DEFAULT_PROJECT)
+
+
+def init_ee(project: str | None = None) -> None:
     """Initialize Earth Engine, using a service account if one is configured.
 
     Falls back to the pre-existing `ee.Initialize(project=project)` behavior (relies on
     locally persisted `earthengine authenticate` credentials) when neither service
     account variable is set, so this is a strict superset of the previous behavior.
+
+    `project` defaults to resolve_project() when not given explicitly, so a caller that
+    just wants "the configured project" doesn't have to resolve it itself first.
     """
+    if project is None:
+        project = resolve_project()
+
     key_json = os.environ.get("GEE_SERVICE_ACCOUNT_JSON")
     key_path = os.environ.get("GEE_SERVICE_ACCOUNT_KEY_FILE")
 

--- a/pipeline/_gee_auth.py
+++ b/pipeline/_gee_auth.py
@@ -1,0 +1,70 @@
+"""Shared Earth Engine init helper used by every GEE-calling stage.
+
+Why this exists:
+    Every stage that talks to GEE (00, 02, 03, 06) called `ee.Initialize(project=...)`
+    directly, which only works after an interactive `earthengine authenticate` has
+    persisted user credentials to disk. That is fine for a developer's own machine but
+    has no path to a headless environment such as a GitHub Actions runner (issue #58).
+
+    This module centralizes Earth Engine initialization so a CI runner can authenticate
+    with a service account (no browser, no interactive prompt) while a local developer's
+    existing `earthengine authenticate` workflow keeps working unchanged: if no service
+    account is configured, behavior is byte-for-byte what it was before this module
+    existed.
+
+Service-account credentials, when present, are read from one of:
+    GEE_SERVICE_ACCOUNT_JSON       the full key JSON as a string (e.g. a GitHub secret)
+    GOOGLE_APPLICATION_CREDENTIALS a path to a key JSON file on disk
+
+Neither is set in this fork/branch and no live GEE credentials were used to test this
+path, see the PR description for what remains unverified.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import ee
+
+
+def init_ee(project: str) -> None:
+    """Initialize Earth Engine, using a service account if one is configured.
+
+    Falls back to the pre-existing `ee.Initialize(project=project)` behavior (relies on
+    locally persisted `earthengine authenticate` credentials) when no service account
+    environment variable is set, so this is a strict superset of the previous behavior.
+    """
+    key_json = os.environ.get("GEE_SERVICE_ACCOUNT_JSON")
+    key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+    if key_json:
+        info = json.loads(key_json)
+        email = info.get("client_email")
+        if not email:
+            raise ValueError("GEE_SERVICE_ACCOUNT_JSON is missing 'client_email'")
+        # ee.ServiceAccountCredentials wants a path, not inline JSON, so spill the
+        # secret to a private temp file for the lifetime of this process only.
+        fd, tmp_path = tempfile.mkstemp(prefix="gee-key-", suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(key_json)
+            credentials = ee.ServiceAccountCredentials(email, tmp_path)
+            ee.Initialize(credentials, project=project)
+        finally:
+            os.remove(tmp_path)
+        return
+
+    if key_path:
+        with open(key_path, encoding="utf-8") as f:
+            info = json.load(f)
+        email = info.get("client_email")
+        if not email:
+            raise ValueError(f"{key_path} is missing 'client_email'")
+        credentials = ee.ServiceAccountCredentials(email, key_path)
+        ee.Initialize(credentials, project=project)
+        return
+
+    # Local-dev path, unchanged from before this module existed.
+    ee.Initialize(project=project)

--- a/pipeline/_publish.py
+++ b/pipeline/_publish.py
@@ -1,0 +1,30 @@
+"""Shared "publish to frontend/public/" helper.
+
+Why this exists:
+    05_hvi.py, 06_nbs.py, 08_sensitivity.py, and 09_ndvi_change.py each copy their own
+    output into frontend/public/ (see pipeline/README.md's "Frontend sync" section) so
+    the browser-fetched copy stays in sync with what the pipeline just computed. The
+    mkdir + shutil.copyfile + "[ok] copied -> ..." sequence was identical in all five
+    call sites across those four files -- the same kind of copy-pasted-per-stage
+    duplication _gee_auth.py already deduped for ee.Initialize() calls.
+
+Deliberately NOT responsible for deciding WHEN to publish: each stage still runs its
+own sanity check and only calls publish() from the `if ok:` branch (see each script's
+"sanity checks" section) -- this function just performs the copy once a caller has
+already decided it's safe to.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def publish(src: Path, dest: Path) -> None:
+    """Copy `src` (already written under data/) to `dest` (under frontend/public/),
+    creating dest's parent directory if needed, and print the confirmation line every
+    stage already printed inline before this was extracted.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dest)
+    print(f"[ok] copied -> {dest}")

--- a/pipeline/diff_snapshots.py
+++ b/pipeline/diff_snapshots.py
@@ -147,7 +147,10 @@ class NbsChange:
 class GreenCoverChange:
     ward_id: str
     old_class: Optional[str]
-    new_class: str
+    # None means the ward has NO classification in the new run at all -- its cells
+    # vanished from cells_ndvi_change.geojson, a data-quality regression worth
+    # surfacing, not "no green-cover change." See diff_green_cover.
+    new_class: Optional[str]
 
 
 @dataclass
@@ -224,10 +227,22 @@ def diff_nbs(old: dict[str, set[str]], new: dict[str, set[str]]) -> list[NbsChan
 
 
 def diff_green_cover(old: dict[str, str], new: dict[str, str]) -> list[GreenCoverChange]:
+    """Same union-over-both-runs pattern as diff_rank/diff_nbs above: iterate every
+    ward that appears in EITHER run, not just wards present in the new run.
+
+    A ward can only be legitimately absent from the union's *union* if it never had a
+    classification in either run, in which case o == n == None and nothing is
+    reported. A ward present in old but missing from new (o is not None, n is None)
+    is a real event -- its cells vanished from cells_ndvi_change.geojson entirely,
+    which diff_rank already flags as "dropped from ranking" and diff_nbs already
+    flags as every intervention being "removed." Silently skipping it here (the
+    previous behavior) hid that same class of data-quality regression instead of
+    surfacing it the way the other two diffs do.
+    """
     changes = []
     for ward_id in sorted(set(old) | set(new)):
         o, n = old.get(ward_id), new.get(ward_id)
-        if n is None or o == n:
+        if o == n:
             continue
         changes.append(GreenCoverChange(ward_id, o, n))
     return changes
@@ -325,9 +340,15 @@ def main() -> int:
         if c.removed:
             print(f"  {c.ward_id}: - {', '.join(c.removed)}")
 
-    print(f"\n{len(result.green_cover_changes)} ward(s) with a green-cover classification flip")
+    print(f"\n{len(result.green_cover_changes)} ward(s) with a green-cover classification change")
     for c in result.green_cover_changes:
-        print(f"  {c.ward_id}: {c.old_class} -> {c.new_class}")
+        if c.new_class is None:
+            print(f"  {c.ward_id}: {c.old_class} -> MISSING (ward has no cells in the new "
+                  "cells_ndvi_change.geojson -- data-quality regression, not \"no change\")")
+        elif c.old_class is None:
+            print(f"  {c.ward_id}: (no previous classification) -> {c.new_class}")
+        else:
+            print(f"  {c.ward_id}: {c.old_class} -> {c.new_class}")
 
     print("\nGO")
     return 0

--- a/pipeline/diff_snapshots.py
+++ b/pipeline/diff_snapshots.py
@@ -1,0 +1,288 @@
+"""M7 — Alert-worthy change detection between two pipeline refreshes (issue #61).
+
+What this is:
+    A pure diff over two runs' worth of pipeline output: given a "before" directory and
+    an "after" directory (each holding `wards_hvi.geojson`, `nbs_recommendations.json`,
+    and `cells_ndvi_change.geojson`), report per ward what actually changed:
+        - HVI rank shift (old rank -> new rank, and by how many places)
+        - NBS recommendations added or removed
+        - Green-cover classification flip (the ward's majority gained/stable/lost class)
+    This is exactly the signal issue #61 asks for: "a saved ward's HVI rank shifts by N
+    places, an NBS recommendation changes, or a green-cover-loss classification flips
+    for that ward" — computed once per refresh, independent of any particular viewer.
+
+What this deliberately is NOT (out of scope, see the PR description):
+    - No per-user "saved wards" filtering. Issue #59 (Supabase Auth + saved-ward
+      profiles) does not exist in this repo yet; when it does, it can filter this
+      script's output down to a user's saved wards rather than duplicating the diff
+      logic itself.
+    - No email sending. This produces a structured diff artifact
+      (`data/pipeline_diff.json` by default); wiring it to a mailer is future work that
+      depends on #59 for "who gets alerted about which wards."
+
+Design notes:
+    Reads only the three GeoJSON/JSON files as plain JSON (stdlib only, no geopandas
+    dependency) so this stays cheap to run and to unit test — see pipeline/tests/
+    test_diff_snapshots.py, which does not need the geospatial stack installed.
+
+    "Before" and "after" are two directories rather than two fixed filenames because in
+    CI (see .github/workflows/pipeline-refresh.yml) "before" is a checkout of the
+    previously-committed data/ before the refresh runs, and "after" is data/ once
+    run_pipeline.py has regenerated it — the diff needs both on disk at once, which two
+    directories give you for free.
+
+Run:
+    python diff_snapshots.py --old-dir /path/to/previous/data --new-dir ../data \
+        --out ../data/pipeline_diff.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+WARDS_HVI_FILENAME = "wards_hvi.geojson"
+NBS_RECS_FILENAME = "nbs_recommendations.json"
+NDVI_CHANGE_FILENAME = "cells_ndvi_change.geojson"
+
+
+def _load_json(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_ward_hvi(data_dir: Path) -> dict[str, dict]:
+    """ward_id -> {"hvi": float | None, "rank": int | None}, from wards_hvi.geojson."""
+    gj = _load_json(data_dir / WARDS_HVI_FILENAME)
+    if gj is None:
+        return {}
+    out = {}
+    for feat in gj.get("features", []):
+        props = feat.get("properties", {})
+        ward_id = props.get("ward_id")
+        if ward_id is None:
+            continue
+        out[str(ward_id)] = {
+            "hvi": props.get("HVI") if props.get("HVI") is not None else props.get("hvi"),
+            "rank": props.get("rank"),
+        }
+    return out
+
+
+def load_nbs_by_ward(data_dir: Path) -> dict[str, set[str]]:
+    """ward_id -> set of intervention names currently recommended, from nbs_recommendations.json."""
+    recs = _load_json(data_dir / NBS_RECS_FILENAME)
+    if recs is None:
+        return {}
+    out: dict[str, set[str]] = {}
+    for r in recs:
+        ward_id = str(r.get("ward_id"))
+        intervention = r.get("intervention")
+        if not ward_id or not intervention:
+            continue
+        out.setdefault(ward_id, set()).add(intervention)
+    return out
+
+
+def load_green_cover_by_ward(data_dir: Path) -> dict[str, str]:
+    """ward_id -> majority per-cell change_class ("gained"/"stable"/"lost"/"unknown"),
+    from cells_ndvi_change.geojson. A ward's cells rarely agree unanimously, so this
+    rolls the cell-level classification up to the single class that describes the
+    ward overall, the same "majority" logic a reader means by "did this ward gain or
+    lose canopy."
+    """
+    gj = _load_json(data_dir / NDVI_CHANGE_FILENAME)
+    if gj is None:
+        return {}
+    classes_by_ward: dict[str, Counter] = {}
+    for feat in gj.get("features", []):
+        props = feat.get("properties", {})
+        ward_id = props.get("ward_id")
+        change_class = props.get("change_class")
+        if ward_id is None or change_class is None:
+            continue
+        classes_by_ward.setdefault(str(ward_id), Counter())[change_class] += 1
+    return {ward_id: counter.most_common(1)[0][0] for ward_id, counter in classes_by_ward.items()}
+
+
+@dataclass
+class RankChange:
+    ward_id: str
+    old_rank: Optional[int]
+    new_rank: Optional[int]
+    delta: Optional[int]  # positive = became MORE vulnerable (worse rank number is lower, so delta = old - new)
+    old_hvi: Optional[float]
+    new_hvi: Optional[float]
+
+
+@dataclass
+class NbsChange:
+    ward_id: str
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GreenCoverChange:
+    ward_id: str
+    old_class: Optional[str]
+    new_class: str
+
+
+@dataclass
+class DiffResult:
+    old_dir: str
+    new_dir: str
+    rank_changes: list[RankChange]
+    nbs_changes: list[NbsChange]
+    green_cover_changes: list[GreenCoverChange]
+    had_baseline: bool  # False if old_dir had none of the three files (e.g. first-ever run)
+
+    def to_json(self) -> dict:
+        return {
+            "old_dir": self.old_dir,
+            "new_dir": self.new_dir,
+            "had_baseline": self.had_baseline,
+            "summary": {
+                "rank_changes": len(self.rank_changes),
+                "nbs_changes": len(self.nbs_changes),
+                "green_cover_changes": len(self.green_cover_changes),
+            },
+            "rank_changes": [
+                {
+                    "ward_id": c.ward_id, "old_rank": c.old_rank, "new_rank": c.new_rank,
+                    "delta": c.delta, "old_hvi": c.old_hvi, "new_hvi": c.new_hvi,
+                }
+                for c in self.rank_changes
+            ],
+            "nbs_changes": [
+                {"ward_id": c.ward_id, "added": sorted(c.added), "removed": sorted(c.removed)}
+                for c in self.nbs_changes
+            ],
+            "green_cover_changes": [
+                {"ward_id": c.ward_id, "old_class": c.old_class, "new_class": c.new_class}
+                for c in self.green_cover_changes
+            ],
+        }
+
+
+def diff_rank(old: dict[str, dict], new: dict[str, dict]) -> list[RankChange]:
+    changes = []
+    for ward_id in sorted(set(old) | set(new)):
+        o, n = old.get(ward_id, {}), new.get(ward_id, {})
+        old_rank, new_rank = o.get("rank"), n.get("rank")
+        if old_rank == new_rank:
+            continue
+        if old_rank is None or new_rank is None:
+            delta = None
+        else:
+            delta = old_rank - new_rank  # positive => moved toward rank 1, i.e. more vulnerable
+        changes.append(RankChange(ward_id, old_rank, new_rank, delta, o.get("hvi"), n.get("hvi")))
+    return changes
+
+
+def diff_nbs(old: dict[str, set[str]], new: dict[str, set[str]]) -> list[NbsChange]:
+    changes = []
+    for ward_id in sorted(set(old) | set(new)):
+        o, n = old.get(ward_id, set()), new.get(ward_id, set())
+        added, removed = n - o, o - n
+        if added or removed:
+            changes.append(NbsChange(ward_id, sorted(added), sorted(removed)))
+    return changes
+
+
+def diff_green_cover(old: dict[str, str], new: dict[str, str]) -> list[GreenCoverChange]:
+    changes = []
+    for ward_id in sorted(set(old) | set(new)):
+        o, n = old.get(ward_id), new.get(ward_id)
+        if n is None or o == n:
+            continue
+        changes.append(GreenCoverChange(ward_id, o, n))
+    return changes
+
+
+def compute_diff(old_dir: Path, new_dir: Path) -> DiffResult:
+    old_files_present = any(
+        (old_dir / name).exists()
+        for name in (WARDS_HVI_FILENAME, NBS_RECS_FILENAME, NDVI_CHANGE_FILENAME)
+    )
+
+    if not old_files_present:
+        # No previous run to compare against (e.g. the very first refresh). Reporting
+        # every ward in the new run as a "change" from nothing would just be noise —
+        # there is nothing alert-worthy about a baseline appearing for the first time.
+        return DiffResult(
+            old_dir=str(old_dir), new_dir=str(new_dir),
+            rank_changes=[], nbs_changes=[], green_cover_changes=[],
+            had_baseline=False,
+        )
+
+    old_rank = load_ward_hvi(old_dir)
+    new_rank = load_ward_hvi(new_dir)
+    old_nbs = load_nbs_by_ward(old_dir)
+    new_nbs = load_nbs_by_ward(new_dir)
+    old_green = load_green_cover_by_ward(old_dir)
+    new_green = load_green_cover_by_ward(new_dir)
+
+    return DiffResult(
+        old_dir=str(old_dir),
+        new_dir=str(new_dir),
+        rank_changes=diff_rank(old_rank, new_rank),
+        nbs_changes=diff_nbs(old_nbs, new_nbs),
+        green_cover_changes=diff_green_cover(old_green, new_green),
+        had_baseline=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--old-dir", required=True, type=Path, help="directory holding the PREVIOUS run's output")
+    parser.add_argument("--new-dir", required=True, type=Path, help="directory holding the CURRENT run's output")
+    parser.add_argument("--out", type=Path, default=None, help="write the diff JSON here (default: print only)")
+    args = parser.parse_args()
+
+    if not args.new_dir.exists():
+        print(f"[FAIL] --new-dir {args.new_dir} does not exist.")
+        return 1
+
+    result = compute_diff(args.old_dir, args.new_dir)
+
+    if not result.had_baseline:
+        print(f"[ok] no previous run found at {args.old_dir} — nothing to diff against (first-ever run?). "
+              "Writing an empty diff.")
+
+    payload = result.to_json()
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"[ok] wrote diff -> {args.out}")
+
+    print(f"\n{len(result.rank_changes)} ward(s) with an HVI rank change")
+    for c in result.rank_changes:
+        direction = "more vulnerable" if (c.delta or 0) > 0 else "less vulnerable"
+        print(f"  {c.ward_id}: rank {c.old_rank} -> {c.new_rank} ({direction})")
+
+    print(f"\n{len(result.nbs_changes)} ward(s) with an NBS recommendation change")
+    for c in result.nbs_changes:
+        if c.added:
+            print(f"  {c.ward_id}: + {', '.join(c.added)}")
+        if c.removed:
+            print(f"  {c.ward_id}: - {', '.join(c.removed)}")
+
+    print(f"\n{len(result.green_cover_changes)} ward(s) with a green-cover classification flip")
+    for c in result.green_cover_changes:
+        print(f"  {c.ward_id}: {c.old_class} -> {c.new_class}")
+
+    print("\nGO")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/diff_snapshots.py
+++ b/pipeline/diff_snapshots.py
@@ -83,11 +83,13 @@ def load_nbs_by_ward(data_dir: Path) -> dict[str, set[str]]:
         return {}
     out: dict[str, set[str]] = {}
     for r in recs:
-        ward_id = str(r.get("ward_id"))
+        ward_id = r.get("ward_id")
         intervention = r.get("intervention")
-        if not ward_id or not intervention:
+        # Check for None BEFORE stringifying: str(None) == "None", a real string, which
+        # would otherwise slip a missing ward_id through as a phantom ward called "None".
+        if ward_id is None or not intervention:
             continue
-        out.setdefault(ward_id, set()).add(intervention)
+        out.setdefault(str(ward_id), set()).add(intervention)
     return out
 
 
@@ -97,6 +99,12 @@ def load_green_cover_by_ward(data_dir: Path) -> dict[str, str]:
     rolls the cell-level classification up to the single class that describes the
     ward overall, the same "majority" logic a reader means by "did this ward gain or
     lose canopy."
+
+    Ties (two classes with the same cell count) are broken alphabetically by class
+    name, not by which class happened to appear first in the GeoJSON's feature order.
+    Feature order isn't guaranteed stable across GEE exports, so breaking ties on it
+    would let the reported "majority" flip between two runs with an identical count
+    distribution and nothing having actually changed.
     """
     gj = _load_json(data_dir / NDVI_CHANGE_FILENAME)
     if gj is None:
@@ -109,7 +117,13 @@ def load_green_cover_by_ward(data_dir: Path) -> dict[str, str]:
         if ward_id is None or change_class is None:
             continue
         classes_by_ward.setdefault(str(ward_id), Counter())[change_class] += 1
-    return {ward_id: counter.most_common(1)[0][0] for ward_id, counter in classes_by_ward.items()}
+
+    result: dict[str, str] = {}
+    for ward_id, counter in classes_by_ward.items():
+        top_count = max(counter.values())
+        tied_classes = sorted(cls for cls, count in counter.items() if count == top_count)
+        result[ward_id] = tied_classes[0]
+    return result
 
 
 @dataclass
@@ -143,13 +157,24 @@ class DiffResult:
     rank_changes: list[RankChange]
     nbs_changes: list[NbsChange]
     green_cover_changes: list[GreenCoverChange]
-    had_baseline: bool  # False if old_dir had none of the three files (e.g. first-ever run)
+    had_baseline: bool  # True if old_dir had AT LEAST ONE of the three files
+    # Per-category baseline flags: whether THAT category's own file existed in
+    # old_dir. A category with had_..._baseline=False was not diffed at all (its
+    # list above is empty because there was nothing to compare, not because nothing
+    # changed) -- see compute_diff's docstring for why this is tracked separately
+    # from had_baseline.
+    had_rank_baseline: bool
+    had_nbs_baseline: bool
+    had_green_cover_baseline: bool
 
     def to_json(self) -> dict:
         return {
             "old_dir": self.old_dir,
             "new_dir": self.new_dir,
             "had_baseline": self.had_baseline,
+            "had_rank_baseline": self.had_rank_baseline,
+            "had_nbs_baseline": self.had_nbs_baseline,
+            "had_green_cover_baseline": self.had_green_cover_baseline,
             "summary": {
                 "rank_changes": len(self.rank_changes),
                 "nbs_changes": len(self.nbs_changes),
@@ -209,35 +234,47 @@ def diff_green_cover(old: dict[str, str], new: dict[str, str]) -> list[GreenCove
 
 
 def compute_diff(old_dir: Path, new_dir: Path) -> DiffResult:
-    old_files_present = any(
-        (old_dir / name).exists()
-        for name in (WARDS_HVI_FILENAME, NBS_RECS_FILENAME, NDVI_CHANGE_FILENAME)
+    """Diff two runs' output, one category at a time.
+
+    Each of the three categories (rank, NBS, green-cover) is gated on the PRESENCE OF
+    ITS OWN file in old_dir, independently of the other two. This matters because a
+    *partial* baseline is a real scenario (e.g. an interrupted first refresh that wrote
+    wards_hvi.geojson but not cells_ndvi_change.geojson yet): treating the baseline as
+    "present" just because *some* file exists, while each loader silently treats its
+    own missing file as an empty dict, would make every ward in the new run look like
+    it "changed" for the categories that actually have no baseline -- a false full-diff
+    instead of "nothing to compare for this category yet."
+    """
+    old_rank_path = old_dir / WARDS_HVI_FILENAME
+    old_nbs_path = old_dir / NBS_RECS_FILENAME
+    old_green_path = old_dir / NDVI_CHANGE_FILENAME
+
+    had_rank_baseline = old_rank_path.exists()
+    had_nbs_baseline = old_nbs_path.exists()
+    had_green_baseline = old_green_path.exists()
+    had_baseline = had_rank_baseline or had_nbs_baseline or had_green_baseline
+
+    rank_changes = (
+        diff_rank(load_ward_hvi(old_dir), load_ward_hvi(new_dir)) if had_rank_baseline else []
     )
-
-    if not old_files_present:
-        # No previous run to compare against (e.g. the very first refresh). Reporting
-        # every ward in the new run as a "change" from nothing would just be noise —
-        # there is nothing alert-worthy about a baseline appearing for the first time.
-        return DiffResult(
-            old_dir=str(old_dir), new_dir=str(new_dir),
-            rank_changes=[], nbs_changes=[], green_cover_changes=[],
-            had_baseline=False,
-        )
-
-    old_rank = load_ward_hvi(old_dir)
-    new_rank = load_ward_hvi(new_dir)
-    old_nbs = load_nbs_by_ward(old_dir)
-    new_nbs = load_nbs_by_ward(new_dir)
-    old_green = load_green_cover_by_ward(old_dir)
-    new_green = load_green_cover_by_ward(new_dir)
+    nbs_changes = (
+        diff_nbs(load_nbs_by_ward(old_dir), load_nbs_by_ward(new_dir)) if had_nbs_baseline else []
+    )
+    green_cover_changes = (
+        diff_green_cover(load_green_cover_by_ward(old_dir), load_green_cover_by_ward(new_dir))
+        if had_green_baseline else []
+    )
 
     return DiffResult(
         old_dir=str(old_dir),
         new_dir=str(new_dir),
-        rank_changes=diff_rank(old_rank, new_rank),
-        nbs_changes=diff_nbs(old_nbs, new_nbs),
-        green_cover_changes=diff_green_cover(old_green, new_green),
-        had_baseline=True,
+        rank_changes=rank_changes,
+        nbs_changes=nbs_changes,
+        green_cover_changes=green_cover_changes,
+        had_baseline=had_baseline,
+        had_rank_baseline=had_rank_baseline,
+        had_nbs_baseline=had_nbs_baseline,
+        had_green_cover_baseline=had_green_baseline,
     )
 
 
@@ -257,6 +294,15 @@ def main() -> int:
     if not result.had_baseline:
         print(f"[ok] no previous run found at {args.old_dir} — nothing to diff against (first-ever run?). "
               "Writing an empty diff.")
+    else:
+        for label, present in [
+            ("wards_hvi.geojson (HVI rank)", result.had_rank_baseline),
+            ("nbs_recommendations.json (NBS)", result.had_nbs_baseline),
+            ("cells_ndvi_change.geojson (green cover)", result.had_green_cover_baseline),
+        ]:
+            if not present:
+                print(f"[WARN] no previous {label} found at {args.old_dir} — that category was not diffed "
+                      "(reported as zero changes below, not verified unchanged).")
 
     payload = result.to_json()
     if args.out:
@@ -266,7 +312,10 @@ def main() -> int:
 
     print(f"\n{len(result.rank_changes)} ward(s) with an HVI rank change")
     for c in result.rank_changes:
-        direction = "more vulnerable" if (c.delta or 0) > 0 else "less vulnerable"
+        if c.delta is None:
+            direction = "newly ranked" if c.old_rank is None else "dropped from ranking"
+        else:
+            direction = "more vulnerable" if c.delta > 0 else "less vulnerable"
         print(f"  {c.ward_id}: rank {c.old_rank} -> {c.new_rank} ({direction})")
 
     print(f"\n{len(result.nbs_changes)} ward(s) with an NBS recommendation change")

--- a/pipeline/format_diff_summary.py
+++ b/pipeline/format_diff_summary.py
@@ -1,0 +1,43 @@
+"""Render data/pipeline_diff.json (diff_snapshots.py's output) as Markdown.
+
+Used by .github/workflows/pipeline-refresh.yml to build the body of the automated
+refresh PR — kept as a standalone script rather than an inline shell heredoc so the
+workflow YAML stays simple and this is testable/runnable on its own.
+
+Run:
+    python format_diff_summary.py ../data/pipeline_diff.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def render(diff: dict) -> str:
+    lines = ["## What changed since the last refresh", ""]
+
+    if not diff.get("had_baseline"):
+        lines.append("No previous run to diff against (first refresh).")
+        return "\n".join(lines)
+
+    s = diff["summary"]
+    lines.append(f"- HVI rank changes: {s['rank_changes']} ward(s)")
+    lines.append(f"- NBS recommendation changes: {s['nbs_changes']} ward(s)")
+    lines.append(f"- Green-cover classification flips: {s['green_cover_changes']} ward(s)")
+    lines.append("")
+    lines.append("Full per-ward diff: `data/pipeline_diff.json` (also attached as a workflow artifact).")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("../data/pipeline_diff.json")
+    if not path.exists():
+        print("Diff step did not produce output — see the workflow run log.")
+        return 0
+    diff = json.loads(path.read_text(encoding="utf-8"))
+    print(render(diff))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/requirements-dev.txt
+++ b/pipeline/requirements-dev.txt
@@ -1,4 +1,12 @@
-# Test-only dependencies. diff_snapshots.py itself has no third-party dependencies
-# (stdlib json only), so this stays separate from requirements.txt's geospatial stack
-# and can be installed on its own in CI.
+# Test-only dependencies, installed on their own in CI rather than pulling in
+# requirements.txt's full geospatial/GEE stack (geopandas, rasterio, osmnx,
+# scikit-learn, scipy, matplotlib, supabase -- none of which pipeline/tests/ needs).
 pytest
+
+# For pipeline/tests/test_gee_auth.py: the `ee` package (earthengine-api) so
+# ee.ServiceAccountCredentials/ee.Initialize exist to monkeypatch, and `cryptography`
+# to generate a throwaway RSA key for the test fixtures. No real Earth Engine
+# credentials or network access are used -- ee.Initialize is monkeypatched in every
+# test, so this stays credential-free like the rest of this file.
+earthengine-api
+cryptography

--- a/pipeline/requirements-dev.txt
+++ b/pipeline/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Test-only dependencies. diff_snapshots.py itself has no third-party dependencies
+# (stdlib json only), so this stays separate from requirements.txt's geospatial stack
+# and can be installed on its own in CI.
+pytest

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -5,6 +5,9 @@ rasterio
 shapely
 scikit-learn
 pandas
+numpy
+scipy
 osmnx
 matplotlib
 supabase
+python-dotenv

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -69,13 +69,23 @@ class Stage:
     script: str
     cadence: str  # "monthly" (satellite/demographic-driven) or "manual" (dev-only gate)
     description: str
-    default: bool = True  # included in a plain `run_pipeline.py` with no flags
+
+    @property
+    def default(self) -> bool:
+        """Whether this stage runs in a plain `run_pipeline.py` with no flags.
+
+        Derived from cadence rather than stored as its own field: right now "manual"
+        cadence and "excluded from the default run" are the same one bit of
+        information (only 00_gee_spike.py is either), and a second, separately-set
+        field for it would just be a second place that bit could drift out of sync
+        as more stages are added later.
+        """
+        return self.cadence != "manual"
 
 
 STAGES: list[Stage] = [
     Stage("00", "00_gee_spike.py", "manual",
-          "Day-0 GEE go/no-go smoke test. Not part of a real refresh; excluded by default.",
-          default=False),
+          "Day-0 GEE go/no-go smoke test. Not part of a real refresh; excluded by default."),
     Stage("01", "01_grid.py", "monthly",
           "Build the 1km grid from BMC ward boundaries. Boundaries essentially never change."),
     Stage("02", "02_gee_layers.py", "monthly",
@@ -110,7 +120,22 @@ class StageResult:
     stage: Stage
     returncode: int | None
     seconds: float
-    status: str  # "ok" | "warn" | "fail" | "skipped"
+
+    @property
+    def status(self) -> str:
+        """"ok" | "warn" | "fail" | "skipped", derived from returncode rather than
+        stored separately: the mapping is a pure function of the exit code a stage's
+        script process actually returned (None for a dry-run stage that never ran), so
+        keeping it as its own field would just be the same information twice, with the
+        two copies free to disagree if one were ever updated without the other.
+        """
+        if self.returncode is None:
+            return "skipped"
+        if self.returncode == 0:
+            return "ok"
+        if self.returncode == 2:
+            return "warn"
+        return "fail"
 
 
 @dataclass
@@ -146,19 +171,36 @@ def parse_stage_ids(raw: str) -> list[str]:
 
 
 def select_stages(args: argparse.Namespace) -> list[Stage]:
+    """Pick which stages to run.
+
+    --only names stages explicitly, and naming a non-default stage (00) that way IS
+    the opt-in: no reason to also require --include-spike when the user just typed
+    "00" themselves. --from applies the same rule for consistency: --from 00 starts
+    the chain AT 00, which only makes sense if the caller meant to include it, so it
+    is treated as its own opt-in too, exactly like --only 00 already was. Without
+    --only or --from naming 00 directly, --include-spike is still required, so a
+    plain `run_pipeline.py` keeps excluding the dev-only spike stage by default.
+    """
     if args.only:
-        return [STAGE_BY_ID[i] for i in parse_stage_ids(args.only)]
+        ids = parse_stage_ids(args.only)
+        explicit_spike = "00" in ids
+        stages = [STAGE_BY_ID[i] for i in ids]
+        if not args.include_spike and not explicit_spike:
+            stages = [s for s in stages if s.default]
+        return stages
 
     ids_in_order = [s.id for s in STAGES]
     start = 0
+    explicit_spike = False
     if args.from_stage:
         start_id = args.from_stage.strip().zfill(2)
         if start_id not in STAGE_BY_ID:
             raise SystemExit(f"unknown --from stage id: {start_id}")
         start = ids_in_order.index(start_id)
+        explicit_spike = start_id == "00"
 
     selected = STAGES[start:]
-    if not args.include_spike:
+    if not args.include_spike and not explicit_spike:
         selected = [s for s in selected if s.default]
     return selected
 
@@ -170,21 +212,15 @@ def run_stage(stage: Stage, dry_run: bool) -> StageResult:
     if dry_run:
         print("[dry-run] would execute: "
               f"{sys.executable} {script_path}")
-        return StageResult(stage, None, 0.0, "skipped")
+        return StageResult(stage, None, 0.0)
 
     start = time.monotonic()
     proc = subprocess.run([sys.executable, str(script_path)], cwd=PIPELINE_DIR)
     elapsed = time.monotonic() - start
 
-    if proc.returncode == 0:
-        status = "ok"
-    elif proc.returncode == 2:
-        status = "warn"
-    else:
-        status = "fail"
-
-    print(f"[{stage.id}] {stage.script} finished in {elapsed:.1f}s -> exit {proc.returncode} ({status})")
-    return StageResult(stage, proc.returncode, elapsed, status)
+    result = StageResult(stage, proc.returncode, elapsed)
+    print(f"[{stage.id}] {stage.script} finished in {elapsed:.1f}s -> exit {proc.returncode} ({result.status})")
+    return result
 
 
 def main() -> int:

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -1,0 +1,248 @@
+"""Orchestrated pipeline runner (issue #56).
+
+Before this script, a data refresh meant running 00_gee_spike.py through
+12_hero_region.py by hand, in the right order, re-reading each script's docstring to
+remember what it needs and what comes next. This wraps that into one command:
+
+    python run_pipeline.py
+
+which runs every stage in dependency order, stops at the first hard failure so a
+partially-updated data/ directory is never mistaken for a complete refresh, and prints
+a clear summary of what ran, what was skipped, and what (if anything) only warned.
+
+Cadence (issue #57 — see pipeline/README.md's "Refresh cadence" section for the full reasoning):
+    Every stage below except 00_gee_spike.py reads or derives from satellite imagery
+    (Landsat LST/NDVI), WorldPop demographics, or ESA WorldCover land cover — all of
+    which change on a monthly-or-slower real-world cadence. Running this chain more
+    often than monthly would re-fetch the same underlying composite and burn GEE quota
+    for a cosmetic "last updated" timestamp, not a real data change. The one genuinely
+    fast-changing signal in this product, live air temperature, is intentionally NOT a
+    pipeline stage: it is fetched client-side per page load in
+    frontend/src/lib/weather.ts, which needs no cron at all.
+
+    00_gee_spike.py is a one-time go/no-go development gate (see its own docstring),
+    not a stage of the data refresh — it queries a tiny fixed test bbox and writes
+    nothing any later stage reads. It is EXCLUDED from the default run; pass
+    --include-spike to run it anyway (e.g. to smoke-test GEE connectivity in CI).
+
+Stopping rule:
+    Each stage script already returns a process exit code: 0 = clean pass, 2 = ran but
+    flagged a "CHECK WARNINGS" sanity check, 1 = hard failure (missing required input,
+    no data returned, etc.). This runner treats 1 as fatal and stops the chain there —
+    every later stage's docstring says "run <earlier stage> first" and its own
+    precondition check would just fail again on stale or missing input. Exit code 2 is
+    logged prominently but does not stop the chain, since a warning (e.g. the PCA
+    fallback triggering) still produces usable output for the next stage.
+
+Usage:
+    python run_pipeline.py                    # run the full monthly refresh, 01..12
+    python run_pipeline.py --include-spike     # also run 00_gee_spike.py first
+    python run_pipeline.py --from 05           # resume from stage 05 onward
+    python run_pipeline.py --only 08,09        # run just these stages
+    python run_pipeline.py --dry-run           # print the plan, run nothing
+    python run_pipeline.py --keep-going        # don't stop on a hard failure
+
+Every run writes a structured log to data/pipeline_run_log.json (stage, exit code,
+duration, timestamp) — this is what issue #61's diff step and the CI workflow (#58)
+both read to know what actually happened.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+PIPELINE_DIR = Path(__file__).resolve().parent
+DATA_DIR = PIPELINE_DIR.parent / "data"
+RUN_LOG_PATH = DATA_DIR / "pipeline_run_log.json"
+
+
+@dataclass
+class Stage:
+    id: str  # two-digit stage number, e.g. "01"
+    script: str
+    cadence: str  # "monthly" (satellite/demographic-driven) or "manual" (dev-only gate)
+    description: str
+    default: bool = True  # included in a plain `run_pipeline.py` with no flags
+
+
+STAGES: list[Stage] = [
+    Stage("00", "00_gee_spike.py", "manual",
+          "Day-0 GEE go/no-go smoke test. Not part of a real refresh; excluded by default.",
+          default=False),
+    Stage("01", "01_grid.py", "monthly",
+          "Build the 1km grid from BMC ward boundaries. Boundaries essentially never change."),
+    Stage("02", "02_gee_layers.py", "monthly",
+          "Dry-season Landsat LST/NDVI composite + WorldCover impervious pct via GEE."),
+    Stage("03", "03_vectors.py", "monthly",
+          "WorldPop population/elderly (pinned annual vintage), slum clusters, OSM hospitals."),
+    Stage("04", "04_zonal.py", "monthly",
+          "Consolidate raster + vector layers into one tidy per-cell table."),
+    Stage("05", "05_hvi.py", "monthly",
+          "PCA-weighted Heat Vulnerability Index per cell, rolled up to wards."),
+    Stage("06", "06_nbs.py", "monthly",
+          "NBS rule engine + ecological plantability filter (WorldCover, via GEE)."),
+    Stage("07", "07_load.py", "monthly",
+          "Upsert Supabase tables and write the demo-safe GeoJSON snapshots."),
+    Stage("08", "08_sensitivity.py", "monthly",
+          "Weight-perturbation sensitivity check and chart."),
+    Stage("09", "09_ndvi_change.py", "monthly",
+          "Classify each cell's NDVI delta as gained/stable/lost."),
+    Stage("10", "10_ward_profile.py", "monthly",
+          "Ward-level descriptive profiles for the dashboard's ward dialog."),
+    Stage("11", "11_hero_city.py", "monthly",
+          "Simplified ward geometry for the landing page's 3D hero model."),
+    Stage("12", "12_hero_region.py", "monthly",
+          "Regional coastline context for the hero model (cached after first fetch)."),
+]
+
+STAGE_BY_ID = {s.id: s for s in STAGES}
+
+
+@dataclass
+class StageResult:
+    stage: Stage
+    returncode: int | None
+    seconds: float
+    status: str  # "ok" | "warn" | "fail" | "skipped"
+
+
+@dataclass
+class RunReport:
+    started_at: str
+    finished_at: str | None = None
+    results: list[StageResult] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        return {
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "stages": [
+                {
+                    "id": r.stage.id,
+                    "script": r.stage.script,
+                    "cadence": r.stage.cadence,
+                    "status": r.status,
+                    "returncode": r.returncode,
+                    "seconds": round(r.seconds, 2),
+                }
+                for r in self.results
+            ],
+        }
+
+
+def parse_stage_ids(raw: str) -> list[str]:
+    ids = [s.strip().zfill(2) for s in raw.split(",") if s.strip()]
+    unknown = [i for i in ids if i not in STAGE_BY_ID]
+    if unknown:
+        raise SystemExit(f"unknown stage id(s): {unknown}. Known: {sorted(STAGE_BY_ID)}")
+    return ids
+
+
+def select_stages(args: argparse.Namespace) -> list[Stage]:
+    if args.only:
+        return [STAGE_BY_ID[i] for i in parse_stage_ids(args.only)]
+
+    ids_in_order = [s.id for s in STAGES]
+    start = 0
+    if args.from_stage:
+        start_id = args.from_stage.strip().zfill(2)
+        if start_id not in STAGE_BY_ID:
+            raise SystemExit(f"unknown --from stage id: {start_id}")
+        start = ids_in_order.index(start_id)
+
+    selected = STAGES[start:]
+    if not args.include_spike:
+        selected = [s for s in selected if s.default]
+    return selected
+
+
+def run_stage(stage: Stage, dry_run: bool) -> StageResult:
+    script_path = PIPELINE_DIR / stage.script
+    print(f"\n{'=' * 70}\n[{stage.id}] {stage.script} ({stage.cadence})\n{stage.description}\n{'=' * 70}")
+
+    if dry_run:
+        print("[dry-run] would execute: "
+              f"{sys.executable} {script_path}")
+        return StageResult(stage, None, 0.0, "skipped")
+
+    start = time.monotonic()
+    proc = subprocess.run([sys.executable, str(script_path)], cwd=PIPELINE_DIR)
+    elapsed = time.monotonic() - start
+
+    if proc.returncode == 0:
+        status = "ok"
+    elif proc.returncode == 2:
+        status = "warn"
+    else:
+        status = "fail"
+
+    print(f"[{stage.id}] {stage.script} finished in {elapsed:.1f}s -> exit {proc.returncode} ({status})")
+    return StageResult(stage, proc.returncode, elapsed, status)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--include-spike", action="store_true",
+                         help="also run 00_gee_spike.py (excluded by default, see module docstring)")
+    parser.add_argument("--from", dest="from_stage", metavar="STAGE_ID",
+                         help="resume the chain starting at this stage id (e.g. 05)")
+    parser.add_argument("--only", metavar="STAGE_IDS",
+                         help="comma-separated stage ids to run instead of the full chain (e.g. 08,09)")
+    parser.add_argument("--dry-run", action="store_true", help="print the execution plan without running anything")
+    parser.add_argument("--keep-going", action="store_true",
+                         help="don't stop the chain on a hard failure (exit code 1)")
+    args = parser.parse_args()
+
+    stages = select_stages(args)
+    if not stages:
+        print("[FAIL] no stages selected.")
+        return 1
+
+    print("Pipeline plan:")
+    for s in stages:
+        print(f"  [{s.id}] {s.script:<20s} ({s.cadence})")
+
+    report = RunReport(started_at=datetime.now(timezone.utc).isoformat())
+    exit_code = 0
+    for stage in stages:
+        result = run_stage(stage, args.dry_run)
+        report.results.append(result)
+        if result.status == "fail" and not args.dry_run:
+            exit_code = 1
+            if not args.keep_going:
+                print(f"\n[FAIL] stage {stage.id} ({stage.script}) failed — stopping the chain. "
+                      f"Fix the failure and resume with: python run_pipeline.py --from {stage.id}")
+                break
+
+    report.finished_at = datetime.now(timezone.utc).isoformat()
+
+    if not args.dry_run:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        RUN_LOG_PATH.write_text(json.dumps(report.to_json(), indent=2), encoding="utf-8")
+        print(f"\n[ok] wrote run log -> {RUN_LOG_PATH}")
+
+    print("\n" + "-" * 70)
+    print("Summary:")
+    for r in report.results:
+        marker = {"ok": "OK", "warn": "WARN", "fail": "FAIL", "skipped": "SKIP"}[r.status]
+        print(f"  [{marker:>4}] {r.stage.id} {r.stage.script}")
+    print("-" * 70)
+
+    if exit_code == 0:
+        any_warn = any(r.status == "warn" for r in report.results)
+        print("GO: pipeline refresh complete." if not any_warn else
+              "GO WITH WARNINGS: pipeline refresh complete, some stages flagged CHECK WARNINGS above.")
+    else:
+        print("FAILED: pipeline refresh did not complete. See the failing stage's output above.")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/tests/test_diff_snapshots.py
+++ b/pipeline/tests/test_diff_snapshots.py
@@ -1,0 +1,166 @@
+"""Tests for diff_snapshots.py (issue #61's diff-computation core).
+
+No geospatial dependencies needed: the module reads GeoJSON as plain JSON, so these
+tests build tiny fixture files directly rather than depending on geopandas/shapely.
+
+Run:
+    pip install -r requirements-dev.txt
+    pytest pipeline/tests/test_diff_snapshots.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from diff_snapshots import compute_diff  # noqa: E402
+
+
+def _write_wards_hvi(dir_path: Path, wards: list[dict]) -> None:
+    features = [
+        {
+            "type": "Feature",
+            "properties": {"ward_id": w["ward_id"], "HVI": w["hvi"], "rank": w["rank"]},
+            "geometry": None,
+        }
+        for w in wards
+    ]
+    (dir_path / "wards_hvi.geojson").write_text(
+        json.dumps({"type": "FeatureCollection", "features": features}), encoding="utf-8"
+    )
+
+
+def _write_nbs_recs(dir_path: Path, recs: list[dict]) -> None:
+    (dir_path / "nbs_recommendations.json").write_text(json.dumps(recs), encoding="utf-8")
+
+
+def _write_ndvi_change(dir_path: Path, cells: list[dict]) -> None:
+    features = [
+        {
+            "type": "Feature",
+            "properties": {"ward_id": c["ward_id"], "change_class": c["change_class"]},
+            "geometry": None,
+        }
+        for c in cells
+    ]
+    (dir_path / "cells_ndvi_change.geojson").write_text(
+        json.dumps({"type": "FeatureCollection", "features": features}), encoding="utf-8"
+    )
+
+
+def test_no_baseline_produces_empty_diff(tmp_path):
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    _write_wards_hvi(new_dir, [{"ward_id": "A", "hvi": 50.0, "rank": 1}])
+
+    result = compute_diff(old_dir, new_dir)
+
+    assert result.had_baseline is False
+    # Nothing to compare against, so nothing is reported as "changed" even though
+    # the new run obviously has data — there is no "before" to diff it against.
+    assert result.rank_changes == []
+
+
+def test_rank_shift_detected():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as old_s, tempfile.TemporaryDirectory() as new_s:
+        old_dir, new_dir = Path(old_s), Path(new_s)
+        _write_wards_hvi(old_dir, [
+            {"ward_id": "A", "hvi": 60.0, "rank": 3},
+            {"ward_id": "B", "hvi": 70.0, "rank": 1},
+        ])
+        _write_wards_hvi(new_dir, [
+            {"ward_id": "A", "hvi": 75.0, "rank": 1},
+            {"ward_id": "B", "hvi": 70.0, "rank": 2},
+        ])
+
+        result = compute_diff(old_dir, new_dir)
+
+        assert result.had_baseline is True
+        by_ward = {c.ward_id: c for c in result.rank_changes}
+        assert set(by_ward) == {"A", "B"}
+        assert by_ward["A"].old_rank == 3
+        assert by_ward["A"].new_rank == 1
+        assert by_ward["A"].delta == 2  # moved 2 places toward rank 1 => more vulnerable
+        assert by_ward["B"].delta == -1
+
+
+def test_unchanged_rank_not_reported():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as old_s, tempfile.TemporaryDirectory() as new_s:
+        old_dir, new_dir = Path(old_s), Path(new_s)
+        _write_wards_hvi(old_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 3}])
+        _write_wards_hvi(new_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 3}])
+
+        result = compute_diff(old_dir, new_dir)
+        assert result.rank_changes == []
+
+
+def test_nbs_recommendation_added_and_removed():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as old_s, tempfile.TemporaryDirectory() as new_s:
+        old_dir, new_dir = Path(old_s), Path(new_s)
+        _write_nbs_recs(old_dir, [
+            {"ward_id": "A", "intervention": "Pocket parks"},
+            {"ward_id": "A", "intervention": "Cool roofs + reflective pavements + cooling centres"},
+        ])
+        _write_nbs_recs(new_dir, [
+            {"ward_id": "A", "intervention": "Pocket parks"},
+            {"ward_id": "A", "intervention": "Native tree planting + green corridors"},
+        ])
+
+        result = compute_diff(old_dir, new_dir)
+
+        assert len(result.nbs_changes) == 1
+        change = result.nbs_changes[0]
+        assert change.ward_id == "A"
+        assert change.added == ["Native tree planting + green corridors"]
+        assert change.removed == ["Cool roofs + reflective pavements + cooling centres"]
+
+
+def test_green_cover_flip_uses_ward_majority_class():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as old_s, tempfile.TemporaryDirectory() as new_s:
+        old_dir, new_dir = Path(old_s), Path(new_s)
+        # Ward A: majority "stable" before, majority "lost" after.
+        _write_ndvi_change(old_dir, [
+            {"ward_id": "A", "change_class": "stable"},
+            {"ward_id": "A", "change_class": "stable"},
+            {"ward_id": "A", "change_class": "gained"},
+        ])
+        _write_ndvi_change(new_dir, [
+            {"ward_id": "A", "change_class": "lost"},
+            {"ward_id": "A", "change_class": "lost"},
+            {"ward_id": "A", "change_class": "stable"},
+        ])
+
+        result = compute_diff(old_dir, new_dir)
+
+        assert len(result.green_cover_changes) == 1
+        change = result.green_cover_changes[0]
+        assert change.ward_id == "A"
+        assert change.old_class == "stable"
+        assert change.new_class == "lost"
+
+
+def test_to_json_roundtrip_is_serializable():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as old_s, tempfile.TemporaryDirectory() as new_s:
+        old_dir, new_dir = Path(old_s), Path(new_s)
+        _write_wards_hvi(old_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 2}])
+        _write_wards_hvi(new_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 1}])
+
+        result = compute_diff(old_dir, new_dir)
+        payload = result.to_json()
+
+        # Must not raise — this is exactly what the CLI and the CI workflow do.
+        serialized = json.dumps(payload)
+        assert "rank_changes" in json.loads(serialized)

--- a/pipeline/tests/test_diff_snapshots.py
+++ b/pipeline/tests/test_diff_snapshots.py
@@ -150,6 +150,76 @@ def test_green_cover_flip_uses_ward_majority_class():
         assert change.new_class == "lost"
 
 
+def test_green_cover_flags_ward_disappearing_from_new_run(tmp_path):
+    """Regression test: diff_rank flags a ward dropping out of the ranking, and
+    diff_nbs flags every intervention for a ward as "removed" when the ward
+    disappears entirely -- but diff_green_cover used to just `continue` (skip) a ward
+    present in old but missing from new, reporting it as zero change instead of the
+    same kind of data-quality regression the other two diffs already surface.
+    """
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    _write_ndvi_change(old_dir, [{"ward_id": "A", "change_class": "stable"}])
+    # Ward A has no cells at all in the new run.
+    _write_ndvi_change(new_dir, [{"ward_id": "B", "change_class": "gained"}])
+
+    result = compute_diff(old_dir, new_dir)
+
+    by_ward = {c.ward_id: c for c in result.green_cover_changes}
+    assert "A" in by_ward, "ward A disappearing must be reported, not silently skipped"
+    assert by_ward["A"].old_class == "stable"
+    assert by_ward["A"].new_class is None
+
+
+def test_green_cover_flags_ward_newly_appearing_in_new_run(tmp_path):
+    """Symmetric case: a ward with no PREVIOUS classification (e.g. a ward that just
+    got its first-ever NDVI-change data) is reported too, matching diff_rank's
+    "newly ranked" case for consistency.
+    """
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    _write_ndvi_change(old_dir, [{"ward_id": "B", "change_class": "gained"}])
+    _write_ndvi_change(new_dir, [
+        {"ward_id": "A", "change_class": "lost"},
+        {"ward_id": "B", "change_class": "gained"},
+    ])
+
+    result = compute_diff(old_dir, new_dir)
+
+    by_ward = {c.ward_id: c for c in result.green_cover_changes}
+    assert "A" in by_ward
+    assert by_ward["A"].old_class is None
+    assert by_ward["A"].new_class == "lost"
+    assert "B" not in by_ward  # unchanged, correctly not reported
+
+
+def test_main_labels_disappeared_ward_in_green_cover_output(tmp_path, monkeypatch, capsys):
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    _write_ndvi_change(old_dir, [{"ward_id": "A", "change_class": "stable"}])
+    _write_ndvi_change(new_dir, [{"ward_id": "B", "change_class": "gained"}])
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["diff_snapshots.py", "--old-dir", str(old_dir), "--new-dir", str(new_dir)],
+    )
+    exit_code = main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "A: stable -> MISSING" in out
+    assert "data-quality regression" in out
+
+
 def test_partial_baseline_does_not_produce_false_full_diff(tmp_path):
     """Regression test: an old_dir that has wards_hvi.geojson but NOT
     nbs_recommendations.json used to be treated as "has a baseline" globally (because

--- a/pipeline/tests/test_diff_snapshots.py
+++ b/pipeline/tests/test_diff_snapshots.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from diff_snapshots import compute_diff  # noqa: E402
+from diff_snapshots import compute_diff, load_green_cover_by_ward, load_nbs_by_ward, main  # noqa: E402
 
 
 def _write_wards_hvi(dir_path: Path, wards: list[dict]) -> None:
@@ -148,6 +148,118 @@ def test_green_cover_flip_uses_ward_majority_class():
         assert change.ward_id == "A"
         assert change.old_class == "stable"
         assert change.new_class == "lost"
+
+
+def test_partial_baseline_does_not_produce_false_full_diff(tmp_path):
+    """Regression test: an old_dir that has wards_hvi.geojson but NOT
+    nbs_recommendations.json used to be treated as "has a baseline" globally (because
+    *a* file existed), while load_nbs_by_ward silently treated its own missing file as
+    {} -- making every ward in the new run's NBS recs look "added" even though there
+    was really no baseline to compare against for that category at all.
+    """
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    # old_dir has a rank baseline but no NBS baseline.
+    _write_wards_hvi(old_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 2}])
+    _write_wards_hvi(new_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 2}])
+    _write_nbs_recs(new_dir, [
+        {"ward_id": "A", "intervention": "Pocket parks"},
+        {"ward_id": "A", "intervention": "Native tree planting + green corridors"},
+    ])
+
+    result = compute_diff(old_dir, new_dir)
+
+    assert result.had_baseline is True  # SOME file existed in old_dir
+    assert result.had_rank_baseline is True
+    assert result.had_nbs_baseline is False
+    # The real fix: no NBS baseline means NBS is not diffed at all, not diffed as
+    # "everything just got added."
+    assert result.nbs_changes == []
+    # The category that DOES have a baseline still gets diffed normally.
+    assert result.rank_changes == []  # rank 2 -> 2, unchanged
+
+
+def test_missing_ward_id_in_nbs_recs_not_treated_as_phantom_ward(tmp_path):
+    """Regression test: str(r.get("ward_id")) used to run before the None-check, so a
+    rec with no ward_id became the literal string "None" and slipped through as a
+    phantom ward in the loaded map and the diff output.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_nbs_recs(data_dir, [
+        {"ward_id": "A", "intervention": "Pocket parks"},
+        {"intervention": "Cool roofs + reflective pavements + cooling centres"},  # no ward_id
+    ])
+
+    by_ward = load_nbs_by_ward(data_dir)
+
+    assert set(by_ward) == {"A"}
+    assert "None" not in by_ward
+
+
+def test_green_cover_tie_break_is_order_independent(tmp_path):
+    """Regression test: Counter.most_common(1) ties-break on GeoJSON feature order,
+    which GEE exports don't guarantee stable across runs. A ward with an identical
+    count distribution (e.g. 2 "gained" / 2 "lost") must resolve to the SAME class
+    regardless of which one appears first in the file, or the reported "majority"
+    could flip between two runs with nothing having actually changed.
+    """
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    # Same 2-2 tie for ward A, features listed in opposite order.
+    _write_ndvi_change(dir_a, [
+        {"ward_id": "A", "change_class": "gained"},
+        {"ward_id": "A", "change_class": "gained"},
+        {"ward_id": "A", "change_class": "lost"},
+        {"ward_id": "A", "change_class": "lost"},
+    ])
+    _write_ndvi_change(dir_b, [
+        {"ward_id": "A", "change_class": "lost"},
+        {"ward_id": "A", "change_class": "lost"},
+        {"ward_id": "A", "change_class": "gained"},
+        {"ward_id": "A", "change_class": "gained"},
+    ])
+
+    result_a = load_green_cover_by_ward(dir_a)
+    result_b = load_green_cover_by_ward(dir_b)
+
+    assert result_a["A"] == result_b["A"]
+    # Deterministic tie-break: alphabetically first among tied classes ("gained" < "lost").
+    assert result_a["A"] == "gained"
+
+
+def test_main_labels_new_and_dropped_ranks_correctly(tmp_path, monkeypatch, capsys):
+    """Regression test: main()'s printed direction label collapsed a None delta (a
+    ward newly appearing in, or dropped entirely from, the ranking) to 0 and always
+    printed "less vulnerable" for those cases, regardless of what actually happened.
+    """
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    # Ward A is newly ranked (no old rank); ward B is dropped (no new rank).
+    _write_wards_hvi(old_dir, [{"ward_id": "B", "hvi": 50.0, "rank": 1}])
+    _write_wards_hvi(new_dir, [{"ward_id": "A", "hvi": 60.0, "rank": 1}])
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["diff_snapshots.py", "--old-dir", str(old_dir), "--new-dir", str(new_dir)],
+    )
+    exit_code = main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "A: rank None -> 1 (newly ranked)" in out
+    assert "B: rank 1 -> None (dropped from ranking)" in out
+    # The old bug printed "less vulnerable" for both of these instead.
+    assert "less vulnerable" not in out
 
 
 def test_to_json_roundtrip_is_serializable():

--- a/pipeline/tests/test_gee_auth.py
+++ b/pipeline/tests/test_gee_auth.py
@@ -1,12 +1,15 @@
 """Tests for _gee_auth.py's env-var routing.
 
-Needs the `ee` package (and, transitively, `cryptography`) to construct a real
-credentials object, so this is skipped when only requirements-dev.txt is installed
-(the lightweight "pipeline" CI job) and runs when the full pipeline/requirements.txt
-stack is present. See pipeline/README.md.
+Needs the `ee` package and `cryptography` (both listed in requirements-dev.txt) to
+construct a real credentials object, so this runs as part of the CI "pipeline" job
+(.github/workflows/ci.yml), which installs requirements-dev.txt. The pytest.importorskip
+calls below are a fallback for running this file directly in an environment with
+neither installed (e.g. a bare `pytest pipeline/tests/` with nothing pip-installed at
+all) -- they make that a clean skip instead of a collection error, not a statement
+that CI itself skips this file.
 
 Run:
-    pip install -r requirements.txt
+    pip install -r requirements-dev.txt
     pytest pipeline/tests/test_gee_auth.py
 """
 
@@ -117,3 +120,32 @@ def test_missing_client_email_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="client_email"):
         _gee_auth.init_ee("proj-x")
+
+
+def test_resolve_project_falls_back_to_default(monkeypatch):
+    """Regression test for the pre-existing "ucip-mumbai" (00_gee_spike.py, matching
+    .env.example) vs "ucip-mum" (02/03/06, typo) drift: every GEE-calling stage now
+    calls this one function instead of its own os.environ.get(..., "<default>") line,
+    so there is exactly one default left to get right.
+    """
+    monkeypatch.delenv("GEE_PROJECT", raising=False)
+    assert _gee_auth.resolve_project() == _gee_auth.DEFAULT_PROJECT == "ucip-mumbai"
+
+
+def test_resolve_project_respects_env_var(monkeypatch):
+    monkeypatch.setenv("GEE_PROJECT", "some-other-project")
+    assert _gee_auth.resolve_project() == "some-other-project"
+
+
+def test_init_ee_defaults_project_to_resolve_project(monkeypatch, captured_init_calls):
+    """init_ee(), called with no project argument at all, must resolve the same
+    project a caller would get from resolve_project() itself -- not silently
+    initialize against ee.Initialize's own unrelated default.
+    """
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY_FILE", raising=False)
+    monkeypatch.delenv("GEE_PROJECT", raising=False)
+
+    _gee_auth.init_ee()
+
+    assert captured_init_calls == [{"credentials": "persistent", "project": "ucip-mumbai"}]

--- a/pipeline/tests/test_gee_auth.py
+++ b/pipeline/tests/test_gee_auth.py
@@ -1,0 +1,119 @@
+"""Tests for _gee_auth.py's env-var routing.
+
+Needs the `ee` package (and, transitively, `cryptography`) to construct a real
+credentials object, so this is skipped when only requirements-dev.txt is installed
+(the lightweight "pipeline" CI job) and runs when the full pipeline/requirements.txt
+stack is present. See pipeline/README.md.
+
+Run:
+    pip install -r requirements.txt
+    pytest pipeline/tests/test_gee_auth.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ee = pytest.importorskip("ee")
+pytest.importorskip("cryptography")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import _gee_auth  # noqa: E402
+
+
+def _fake_rsa_key_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+@pytest.fixture
+def fake_service_account_json() -> str:
+    return json.dumps({
+        "type": "service_account",
+        "client_email": "svc@example.iam.gserviceaccount.com",
+        "private_key": _fake_rsa_key_pem(),
+        "private_key_id": "abc123",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    })
+
+
+@pytest.fixture
+def captured_init_calls(monkeypatch):
+    calls = []
+
+    def fake_initialize(credentials="persistent", project=None):
+        calls.append({"credentials": credentials, "project": project})
+
+    monkeypatch.setattr(ee, "Initialize", fake_initialize)
+    return calls
+
+
+def test_no_env_vars_falls_back_to_plain_initialize(monkeypatch, captured_init_calls):
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY_FILE", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    _gee_auth.init_ee("proj-x")
+
+    assert captured_init_calls == [{"credentials": "persistent", "project": "proj-x"}]
+
+
+def test_ambient_google_application_credentials_is_ignored(monkeypatch, captured_init_calls):
+    """The bug this guards against: a dev with GOOGLE_APPLICATION_CREDENTIALS set for
+    unrelated GCP tooling must NOT be silently routed into the service-account branch.
+    """
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY_FILE", raising=False)
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/ambient-cred.json")
+
+    _gee_auth.init_ee("proj-x")
+
+    # If the ambient var were picked up, this would raise FileNotFoundError trying to
+    # open a path that doesn't exist. Reaching here with the plain fallback call proves
+    # it wasn't.
+    assert captured_init_calls == [{"credentials": "persistent", "project": "proj-x"}]
+
+
+def test_service_account_json_env_var_used(monkeypatch, captured_init_calls, fake_service_account_json):
+    monkeypatch.setenv("GEE_SERVICE_ACCOUNT_JSON", fake_service_account_json)
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY_FILE", raising=False)
+
+    _gee_auth.init_ee("proj-y")
+
+    assert len(captured_init_calls) == 1
+    assert captured_init_calls[0]["project"] == "proj-y"
+    credentials = captured_init_calls[0]["credentials"]
+    assert credentials != "persistent"
+    assert credentials.service_account_email == "svc@example.iam.gserviceaccount.com"
+
+
+def test_service_account_key_file_env_var_used(monkeypatch, tmp_path, captured_init_calls, fake_service_account_json):
+    key_path = tmp_path / "key.json"
+    key_path.write_text(fake_service_account_json, encoding="utf-8")
+
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.setenv("GEE_SERVICE_ACCOUNT_KEY_FILE", str(key_path))
+
+    _gee_auth.init_ee("proj-z")
+
+    assert len(captured_init_calls) == 1
+    assert captured_init_calls[0]["project"] == "proj-z"
+    assert captured_init_calls[0]["credentials"] != "persistent"
+
+
+def test_missing_client_email_raises(monkeypatch):
+    monkeypatch.setenv("GEE_SERVICE_ACCOUNT_JSON", json.dumps({"private_key": "x"}))
+    monkeypatch.delenv("GEE_SERVICE_ACCOUNT_KEY_FILE", raising=False)
+
+    with pytest.raises(ValueError, match="client_email"):
+        _gee_auth.init_ee("proj-x")

--- a/pipeline/tests/test_publish.py
+++ b/pipeline/tests/test_publish.py
@@ -1,0 +1,65 @@
+"""Tests for _publish.py, the shared "copy to frontend/public/" helper used by
+05_hvi.py, 06_nbs.py, 08_sensitivity.py, and 09_ndvi_change.py.
+
+No third-party dependencies.
+
+Run:
+    pip install -r requirements-dev.txt
+    pytest pipeline/tests/test_publish.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _publish import publish  # noqa: E402
+
+
+def test_publish_copies_file_contents(tmp_path):
+    src = tmp_path / "data" / "wards_hvi.geojson"
+    src.parent.mkdir()
+    src.write_text('{"type": "FeatureCollection", "features": []}', encoding="utf-8")
+
+    dest = tmp_path / "public" / "wards_hvi.geojson"
+
+    publish(src, dest)
+
+    assert dest.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
+
+
+def test_publish_creates_missing_parent_directory(tmp_path):
+    src = tmp_path / "src.json"
+    src.write_text("{}", encoding="utf-8")
+
+    dest = tmp_path / "does" / "not" / "exist" / "yet" / "dest.json"
+    assert not dest.parent.exists()
+
+    publish(src, dest)
+
+    assert dest.exists()
+    assert dest.read_text(encoding="utf-8") == "{}"
+
+
+def test_publish_overwrites_existing_dest(tmp_path):
+    src = tmp_path / "src.json"
+    src.write_text("new content", encoding="utf-8")
+
+    dest = tmp_path / "dest.json"
+    dest.write_text("stale content", encoding="utf-8")
+
+    publish(src, dest)
+
+    assert dest.read_text(encoding="utf-8") == "new content"
+
+
+def test_publish_prints_confirmation(tmp_path, capsys):
+    src = tmp_path / "src.json"
+    src.write_text("{}", encoding="utf-8")
+    dest = tmp_path / "dest.json"
+
+    publish(src, dest)
+
+    out = capsys.readouterr().out
+    assert "[ok] copied" in out
+    assert str(dest) in out

--- a/pipeline/tests/test_run_pipeline.py
+++ b/pipeline/tests/test_run_pipeline.py
@@ -1,0 +1,86 @@
+"""Tests for run_pipeline.py's stage-selection logic and derived properties.
+
+No third-party dependencies: this only exercises argument parsing and the STAGES
+table, never actually runs a pipeline stage subprocess.
+
+Run:
+    pip install -r requirements-dev.txt
+    pytest pipeline/tests/test_run_pipeline.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import run_pipeline as rp  # noqa: E402
+
+
+def _parse(argv: list[str]):
+    parser = __import__("argparse").ArgumentParser()
+    parser.add_argument("--include-spike", action="store_true")
+    parser.add_argument("--from", dest="from_stage")
+    parser.add_argument("--only")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--keep-going", action="store_true")
+    return parser.parse_args(argv)
+
+
+def test_plain_run_excludes_spike_stage():
+    stages = rp.select_stages(_parse([]))
+    assert [s.id for s in stages] == [s.id for s in rp.STAGES if s.id != "00"]
+
+
+def test_include_spike_flag_includes_it():
+    stages = rp.select_stages(_parse(["--include-spike"]))
+    assert stages[0].id == "00"
+
+
+def test_from_00_without_include_spike_now_includes_it():
+    """Regression test: --include-spike used to gate --from but not --only, so
+    --from 00 silently dropped stage 00 while --only 00 ran it -- same intent
+    (explicitly naming stage 00), opposite outcome, no message either way. Naming 00
+    directly via --from is now its own opt-in, consistent with --only.
+    """
+    stages = rp.select_stages(_parse(["--from", "00"]))
+    assert stages[0].id == "00"
+
+
+def test_only_00_without_include_spike_includes_it():
+    """The other half of the same consistency fix: --only 00 already worked this way
+    and must keep working this way.
+    """
+    stages = rp.select_stages(_parse(["--only", "00"]))
+    assert [s.id for s in stages] == ["00"]
+
+
+def test_from_05_without_include_spike_excludes_spike():
+    """Naming a later stage must not accidentally pull in 00 -- only an explicit
+    reference to "00" itself is treated as opt-in.
+    """
+    stages = rp.select_stages(_parse(["--from", "05"]))
+    assert stages[0].id == "05"
+    assert "00" not in [s.id for s in stages]
+
+
+def test_only_05_without_include_spike_excludes_spike():
+    stages = rp.select_stages(_parse(["--only", "05,08"]))
+    assert [s.id for s in stages] == ["05", "08"]
+
+
+def test_stage_default_derived_from_cadence():
+    spike = rp.STAGE_BY_ID["00"]
+    grid = rp.STAGE_BY_ID["01"]
+    assert spike.cadence == "manual"
+    assert spike.default is False
+    assert grid.cadence == "monthly"
+    assert grid.default is True
+
+
+def test_stage_result_status_derived_from_returncode():
+    stage = rp.STAGE_BY_ID["01"]
+    assert rp.StageResult(stage, 0, 1.0).status == "ok"
+    assert rp.StageResult(stage, 2, 1.0).status == "warn"
+    assert rp.StageResult(stage, 1, 1.0).status == "fail"
+    assert rp.StageResult(stage, 137, 1.0).status == "fail"
+    assert rp.StageResult(stage, None, 0.0).status == "skipped"


### PR DESCRIPTION
## What and why

This PR addresses five connected v2/signature issues about turning UCIP's pipeline from
"13 scripts run by hand" into an orchestrated, scheduled, diffable refresh, plus
publishing the existing HVI methodology as a standalone report.

Closes #56, Closes #57, Closes #58, Closes #61, Closes #66

### #56 - Orchestrate the 13 pipeline stages into one runnable chain

Added `pipeline/run_pipeline.py`, which runs `01_grid.py` through
`12_hero_region.py` in dependency order from one command, stops the chain on the
first hard failure (a stage's own exit code 1), continues past a soft warning
(exit code 2), and writes a structured run log to `data/pipeline_run_log.json`.
Supports `--from`, `--only`, `--dry-run`, `--keep-going`.

`00_gee_spike.py` is excluded from a default run. Reading its docstring, it's a
one-time development go/no-go gate that queries a small fixed test bbox and writes
nothing any later stage reads, not a stage of a real data refresh. It stays runnable
via `--include-spike`.

**Verified:** ran the orchestrator end to end locally against every non-GEE stage
(`01, 04, 05, 08, 09, 10, 11, 07`) with real repo data in a clean virtualenv; all
passed with exit 0 and produced output identical to the already-committed data
(diffed byte-for-byte against a pre-run backup). GEE-calling stages (`00, 02, 03, 06`)
and the OSM-calling stage (`03`) were not runnable here since this environment has no
Earth Engine or OSM credentials; their logic was read carefully but not executed.

### #57 - Split refresh cadence by what's physically real

Every stage is tagged with a cadence in `run_pipeline.py`'s stage table and documented
in the new `pipeline/README.md`: all 13 stages are `monthly`, because the data behind
them (Landsat LST/NDVI composites, WorldPop's pinned annual vintage, ESA WorldCover)
does not change daily in reality. Running this pipeline more often would just re-fetch
the same composite for a cosmetic timestamp, at real GEE-quota cost.

The one genuinely fast-changing value in the product, live air temperature, is
intentionally **not** a pipeline stage. It already updates independently, client-side,
via `frontend/src/lib/weather.ts` on every page load, no cron needed. `pipeline/README.md`
documents this explicitly as the pattern any future fast-changing value should follow.

### #58 - Automate pipeline refresh via GitHub Actions cron

Added `.github/workflows/pipeline-refresh.yml`: a monthly cron
(`17 3 1 * *` UTC) plus `workflow_dispatch`, that installs
`pipeline/requirements.txt`, runs `run_pipeline.py`, runs the new diff step (#61)
against the pre-refresh `data/`, and opens a PR (via `peter-evans/create-pull-request`)
with the regenerated `data/` and `frontend/public/*.json`, plus a diff summary in the
PR body. All required secrets (`GEE_PROJECT`, `GEE_SERVICE_ACCOUNT_JSON`,
`NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) are referenced only via
`secrets.*`; none are configured in this fork.

Also added `pipeline/_gee_auth.py`: every GEE-calling stage previously called
`ee.Initialize(project=...)` directly, which only works after an interactive
`earthengine authenticate` on that machine, with no path to a headless CI runner. The
new helper authenticates with a service account when `GEE_SERVICE_ACCOUNT_JSON` (or
`GOOGLE_APPLICATION_CREDENTIALS`) is set, and otherwise falls back to the exact
previous behavior, so local dev is unaffected.

**Honesty about verification:** this workflow has **not** been run against real Earth
Engine or Supabase credentials, and cannot be from a contributor's fork. Only the YAML
structure (parsed and validated locally) and the scripts it calls (each independently
tested, see above and below) have been verified. The maintainer will need to add the
four secrets before this runs for real, and should sanity-check the first live run.

### #61 - Define alert-worthy change detection per pipeline refresh

Added `pipeline/diff_snapshots.py`: given a "before" and "after" directory of pipeline
output, it reports per ward: HVI rank shifts, NBS recommendations added/removed, and
green-cover classification flips (majority per-cell class rolled up to ward level).
Pure diff, stdlib-only (no geopandas dependency), with a CLI and a `compute_diff()`
function others can call directly.

**Out of scope, explicitly:** no per-user "saved wards" filtering and no email sending.
Issue #59 (Supabase Auth + saved-ward profiles) doesn't exist in this repo yet; once it
does, it can filter this script's output down to a user's saved wards rather than this
script owning that logic. This PR only builds the reusable, account-agnostic diff core,
which is the real prerequisite #61 asked for.

**Verified:** 6 unit tests (`pipeline/tests/test_diff_snapshots.py`) covering rank
shifts, NBS add/remove, green-cover flips, the no-baseline case, and JSON
serialization, all passing. Also smoke-tested the CLI against this repo's real
`data/` (diffing it against itself correctly reports zero changes). Added a lightweight
`pipeline` job to `.github/workflows/ci.yml` that installs only `pytest` and runs these
tests (no geospatial stack needed, since the module has no third-party dependencies).

### #66 - Publish the HVI methodology as a proper technical report

Added `docs/HVI-methodology-report.md`: abstract, prior art, data sources, indicators,
PCA weighting method and current weights, sensitivity analysis results, the NBS engine
and ecological plantability filter, green-cover-change classification, an illustrative-
coefficients section, limitations, and a full reference table. Every number in it (PCA
weights, explained variance, Kendall-tau/top-5-overlap sensitivity results, plantable
cell counts, NBS recommendation counts by type, NDVI-change class counts) was read
directly from this repo's committed pipeline output (`data/hvi_pca_log.json`,
`data/sensitivity.json`, `data/nbs_recommendations.json`, `data/cells_ndvi_change.geojson`)
and pipeline source, not invented or estimated.

**Not submitted anywhere.** This PR produces the writeup itself, as instructed; actual
submission to arXiv, SSRN, or a personal research page is a decision for the maintainer.

## What was verified vs. not

- Verified locally: `run_pipeline.py`'s control flow (dry-run, `--from`, `--only`,
  `--include-spike`) and a full end-to-end run of every non-GEE/non-OSM stage against
  real repo data; all 6 `diff_snapshots.py` unit tests; the diff CLI against real data;
  `.github/workflows/*.yml` YAML syntax; `npm run lint` and `npm run build` (frontend
  untouched by this PR, included for completeness per CONTRIBUTING).
- Not verified, and said so above rather than claimed otherwise: any GEE-calling stage
  end to end (no Earth Engine credentials here), the Supabase upsert path in `07_load.py`
  (falls back gracefully with no `.env.local`, as designed), and the scheduled workflow
  itself running live (no secrets configured, no way to trigger a real scheduled run
  from a fork).

## Out of scope (explicit)

- #61's per-user "saved ward" filtering and email delivery, pending #59.
- The Supabase-read migration mentioned in #58 (explicitly called out as a separate v1
  issue, not part of this PR).
- Actually submitting #66's report to arXiv/SSRN/a personal page.

## Checklist

- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] New Python tests pass (`pytest pipeline/tests/`)
- [x] Docs updated in the same PR (`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`,
      new `pipeline/README.md` and `docs/HVI-methodology-report.md`)
- [x] No secrets, credentials, or personal paths committed
