### PR TITLE
feat: surface the data refresh date and imagery window on the site (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Prototype under active development ahead of the Aug 8, 2026 submission. No tagge
 yet — this section covers everything since the project started.
 
 ### Added
+- The site now says how old its data is: a "Data vintage" note on /methodology and a
+  footer bar on the dashboard show the last pipeline-refresh date alongside the dry-season
+  imagery window it was computed from (surfaced from the pipeline run log via
+  /api/v1/meta; issue #124). The pipeline run log now records that window and is mirrored
+  to `frontend/public/`, so the note updates itself on every refresh.
 - End-to-end data pipeline: dry-season Landsat 8/9 LST + NDVI composite, WorldPop
   population/elderly layer (pinned to the 2020 vintage), OSM hospital distance, Datameet
   ward + slum-cluster boundaries.

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,10 @@ Supabase project being deleted in September 2026.
 
 What this deployment is serving: coverage, row counts, the weighting method
 actually used (PCA, or the published-literature fallback if the PCA was
-rejected), licence terms and links.
+rejected), licence terms and links. It also reports `generated_at` (when the
+pipeline last refreshed the data) and `composite_window` (the dry-season Landsat
+window the figures were computed from); both are null until a refresh run has
+committed its run log.
 
 ### `GET /wards`
 

--- a/frontend/src/app/api/v1/api.test.ts
+++ b/frontend/src/app/api/v1/api.test.ts
@@ -44,6 +44,40 @@ describe("GET /api/v1/meta", () => {
     expect(json.counts.citations).toBeGreaterThan(0);
     expect(json.license.code).toBe("Apache-2.0");
   });
+
+  it("nulls the data-vintage fields until a committed run log exists", async () => {
+    const json = await body(await getMeta());
+    // The repo has no committed pipeline_run_log.json yet, so the endpoint must
+    // not invent a refresh date. This is the honest answer until the first
+    // refresh run commits one.
+    expect(json.generated_at).toBeNull();
+    expect(json.composite_window).toBeNull();
+  });
+
+  it("reports the refresh date and composite window from the run log", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const logPath = path.join(process.cwd(), "public", "pipeline_run_log.json");
+    try {
+      await fs.writeFile(
+        logPath,
+        JSON.stringify({
+          started_at: "2026-09-03T04:00:00+00:00",
+          finished_at: "2026-09-03T05:30:00+00:00",
+          composite_window: { start: "2025-11-01", end: "2026-02-28" },
+          stages: [],
+        })
+      );
+      const json = await body(await getMeta());
+      expect(json.generated_at).toBe("2026-09-03T05:30:00+00:00");
+      expect(json.composite_window).toEqual({
+        start: "2025-11-01",
+        end: "2026-02-28",
+      });
+    } finally {
+      await fs.rm(logPath, { force: true });
+    }
+  });
 });
 
 describe("GET /api/v1/wards", () => {

--- a/frontend/src/app/api/v1/meta/route.ts
+++ b/frontend/src/app/api/v1/meta/route.ts
@@ -8,10 +8,14 @@
  * this endpoint exists rather than just a version string. "Refreshed last week"
  * and "computed from imagery captured last winter" are both true at once, and a
  * consumer needs the second one to know how old the underlying measurements are.
+ *
+ * Both values come from the committed pipeline run log and are null until a
+ * refresh run has committed one; see the GET handler's comment.
  */
 
 import type { FeatureCollection, Geometry } from "geojson";
 import type { NbsRec, WardProps } from "@/lib/wardTypes";
+import type { RunLog } from "@/lib/runLog";
 import { API_VERSION, jsonResponse, optionsResponse, readSnapshot, supabase } from "../_lib";
 import { CITATIONS } from "@/lib/citations";
 import { MUMBAI } from "@/lib/city";
@@ -23,9 +27,14 @@ export function OPTIONS() {
 }
 
 export async function GET() {
-  const [wards, recs] = await Promise.all([
+  const [wards, recs, runLog] = await Promise.all([
     readSnapshot<FeatureCollection<Geometry, WardProps>>("wards_hvi.geojson").catch(() => null),
     readSnapshot<NbsRec[]>("nbs_recommendations.json").catch(() => null),
+    // The committed mirror of pipeline/run_pipeline.py's run log. It only exists
+    // once a pipeline run has committed one (data/** and frontend/public/*.json
+    // ride the automated refresh PR), so both fields below are null until then:
+    // reporting a guessed date would defeat the point of this endpoint.
+    readSnapshot<RunLog>("pipeline_run_log.json").catch(() => null),
   ]);
 
   const pcaLog = await readSnapshot<{
@@ -48,6 +57,12 @@ export async function GET() {
       recommendations: recs?.length ?? null,
       citations: CITATIONS.length,
     },
+    // When the data this deployment serves was last produced, and the Landsat
+    // dry-season window it was computed from. finished_at is the end of the
+    // last full run; started_at is the fallback for a log written by a run that
+    // never completed.
+    generated_at: runLog?.finished_at ?? runLog?.started_at ?? null,
+    composite_window: runLog?.composite_window ?? null,
     method: {
       index: "Heat Vulnerability Index, 0-100, from seven standardised indicators",
       weighting: pcaLog?.fallback_used

--- a/frontend/src/app/components/DataVintageBar.tsx
+++ b/frontend/src/app/components/DataVintageBar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/**
+ * The dashboard footer's data-vintage line (issue #124).
+ *
+ * Reads /api/v1/meta, which reports `generated_at` and `composite_window` from
+ * the committed pipeline run log. Renders nothing until that log exists — the
+ * first refresh run after this ships will commit one, and the bar appears and
+ * then updates itself on every later refresh, with no redeploy logic of its
+ * own (the API response is cached at the edge, so refreshes propagate within
+ * the cache window).
+ *
+ * Rendered as a sibling of the map rather than inside it on purpose: the
+ * freshness statement is meta-information about the whole dashboard, not about
+ * the current ward, so it sits outside the ward-selection chrome that changes
+ * as the visitor navigates.
+ */
+
+import { useEffect, useState } from "react";
+import { formatCompositeWindow, formatRunDate } from "@/lib/runLog";
+
+interface MetaResponse {
+  generated_at: string | null;
+  composite_window: { start: string; end: string } | null;
+}
+
+export default function DataVintageBar() {
+  const [meta, setMeta] = useState<MetaResponse | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/v1/meta", { signal: controller.signal })
+      .then((res) => (res.ok ? (res.json() as Promise<MetaResponse>) : null))
+      .then((json) => setMeta(json))
+      // A failed meta fetch must never take the dashboard down with it; the
+      // bar is informational. Absence and error both just mean "no line".
+      .catch(() => setMeta(null));
+    return () => controller.abort();
+  }, []);
+
+  const refreshDate = formatRunDate(meta?.generated_at);
+  if (!refreshDate) return null;
+
+  const windowLabel = formatCompositeWindow(meta?.composite_window ?? null);
+
+  return (
+    <footer className="border-t border-border bg-background px-4 py-1.5">
+      <p className="text-center text-[11px] text-muted-foreground sm:text-left">
+        {windowLabel ? (
+          <>
+            Data refreshed {refreshDate} &middot; computed from imagery captured{" "}
+            {windowLabel}
+          </>
+        ) : (
+          <>Data refreshed {refreshDate}</>
+        )}
+      </p>
+    </footer>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import WardPanel from "../components/WardPanel";
 import WardDialog from "../components/WardDialog";
 import SiteHeader from "../components/SiteHeader";
+import DataVintageBar from "../components/DataVintageBar";
 import {
   parseWardParam,
   readStoredWards,
@@ -216,6 +217,9 @@ function DashboardContent() {
         onSelectWard={selectWard}
         enabled={dialogHandlesWard}
       />
+      {/* The data-vintage bar is dashboard chrome like the header and hint, so
+          it follows the same fullscreen guard (issue #124). */}
+      {!isFullscreen && <DataVintageBar />}
     </div>
   );
 }

--- a/frontend/src/app/methodology/page.tsx
+++ b/frontend/src/app/methodology/page.tsx
@@ -7,6 +7,11 @@ import SiteFooter from "../components/SiteFooter";
 import { StepCard } from "../components/Card";
 import { CitationList } from "../components/Citation";
 import CoefficientSparkline from "../components/CoefficientSparkline";
+import {
+  formatCompositeWindow,
+  formatRunDate,
+  type RunLog,
+} from "@/lib/runLog";
 
 export const metadata: Metadata = {
   title: "Methodology | UCIP",
@@ -71,6 +76,14 @@ export default function MethodologyPage() {
   const pca = readJson<PcaLog>("hvi_pca_log.json");
   const sensitivity = readJson<Sensitivity>("sensitivity.json");
   const validation = readJsonOptional<LstValidation>("lst_validation.json");
+  // Read from ../data/ like sensitivity.json and hvi_pca_log.json above (see the
+  // "Frontend sync" section of pipeline/README.md). Absent until a pipeline run
+  // commits its log, so the block below renders nothing on a fresh checkout.
+  const runLog = readJsonOptional<RunLog>("pipeline_run_log.json");
+  const refreshedLabel = runLog
+    ? formatRunDate(runLog.finished_at ?? runLog.started_at)
+    : null;
+  const windowLabel = runLog ? formatCompositeWindow(runLog.composite_window) : null;
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -91,6 +104,24 @@ export default function MethodologyPage() {
           city&apos;s 24 BMC wards on a 1km grid, though the approach itself isn&apos;t tied to Mumbai
           specifically, we just haven&apos;t built out other cities yet.
         </p>
+
+        {refreshedLabel && (
+          <div className="mt-8 rounded-xl border border-border bg-surface p-6">
+            <p className="kicker">Data vintage</p>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Refreshed{" "}
+              <strong className="font-medium text-foreground">{refreshedLabel}</strong>
+              {windowLabel && (
+                <>
+                  . The underlying measurements come from Landsat imagery captured{" "}
+                  <strong className="font-medium text-foreground">{windowLabel}</strong>
+                  , Mumbai&apos;s most recent complete dry season — the refresh date alone
+                  overstates how current the figures are.
+                </>
+              )}
+            </p>
+          </div>
+        )}
 
         <div className="mt-8 space-y-6">
           <StepCard step={1} title="What we measure" description="Seven standardized indicators, each z-scored.">

--- a/frontend/src/lib/runLog.test.ts
+++ b/frontend/src/lib/runLog.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCompositeWindow,
+  formatRunDate,
+  formatWindowDate,
+} from "./runLog";
+
+describe("formatRunDate", () => {
+  it("formats a UTC timestamp as a plain date, in UTC", () => {
+    // +00:00 and Z are the two spellings Python's datetime.isoformat() emits.
+    expect(formatRunDate("2026-09-03T12:40:11+00:00")).toBe("3 Sep 2026");
+    expect(formatRunDate("2026-09-03T23:59:59Z")).toBe("3 Sep 2026");
+  });
+
+  it("does not shift a late-UTC timestamp into another day", () => {
+    // Regression guard for the timeZone: "UTC" choice — rendered in IST this
+    // instant would be 4 Sep.
+    expect(formatRunDate("2026-09-03T20:00:00Z")).toBe("3 Sep 2026");
+  });
+
+  it("returns null for missing or unparseable input", () => {
+    expect(formatRunDate(null)).toBeNull();
+    expect(formatRunDate(undefined)).toBeNull();
+    expect(formatRunDate("")).toBeNull();
+    expect(formatRunDate("not a date")).toBeNull();
+  });
+});
+
+describe("formatWindowDate", () => {
+  it("formats date-only bounds", () => {
+    expect(formatWindowDate("2025-11-01")).toBe("1 Nov 2025");
+    expect(formatWindowDate("2026-02-28")).toBe("28 Feb 2026");
+    expect(formatWindowDate("2024-02-29")).toBe("29 Feb 2024");
+  });
+
+  it("returns null for missing or unparseable input", () => {
+    expect(formatWindowDate(null)).toBeNull();
+    expect(formatWindowDate("2026-13-01")).toBeNull();
+  });
+});
+
+describe("formatCompositeWindow", () => {
+  it("renders the range with an en dash", () => {
+    expect(
+      formatCompositeWindow({ start: "2025-11-01", end: "2026-02-28" })
+    ).toBe("1 Nov 2025 – 28 Feb 2026");
+  });
+
+  it("returns null when either bound is missing or invalid", () => {
+    expect(formatCompositeWindow(null)).toBeNull();
+    expect(formatCompositeWindow(undefined)).toBeNull();
+    expect(formatCompositeWindow({ start: "", end: "2026-02-28" })).toBeNull();
+    expect(formatCompositeWindow({ start: "2025-11-01", end: "nope" })).toBeNull();
+  });
+});

--- a/frontend/src/lib/runLog.ts
+++ b/frontend/src/lib/runLog.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared types and formatting for the pipeline run log (data/pipeline_run_log.json).
+ *
+ * Why this exists as a lib: the run log is what makes the site's data-age story
+ * honest (issue #124). Three consumers read it — /api/v1/meta (raw values),
+ * the /methodology page and the dashboard footer bar (human labels) — and they
+ * must agree on its shape and on how the dates are written. A refresh date
+ * alone overstates freshness, so the log also carries the dry-season window the
+ * run's figures were computed from, and callers show the two as one statement.
+ *
+ * The file is written by pipeline/run_pipeline.py and mirrored to
+ * frontend/public/ (see pipeline/README.md's "Frontend sync" table). It only
+ * exists in the repo once a pipeline run has committed it, so every consumer
+ * treats its absence as "no refresh has been recorded yet" and renders nothing
+ * rather than a guessed date.
+ */
+
+/** ISO 8601 timestamps, written by run_pipeline.py as UTC (`...Z` or `+00:00`). */
+export interface CompositeWindow {
+  /** First day of the season, e.g. "2025-11-01". */
+  start: string;
+  /** Last day of the season, e.g. "2026-02-28". */
+  end: string;
+}
+
+export interface RunStage {
+  id: string;
+  script: string;
+  status: "ok" | "warn" | "fail" | "skipped";
+  returncode: number | null;
+  seconds: number;
+}
+
+export interface RunLog {
+  started_at: string;
+  finished_at: string | null;
+  /** Present on every log this project writes going forward (issue #124). */
+  composite_window: CompositeWindow | null;
+  stages: RunStage[];
+}
+
+/**
+ * Dates are rendered as e.g. "3 Sep 2026". Written by hand rather than
+ * Intl.DateTimeFormat because the abbreviation is locale-dependent even at a
+ * fixed timeZone (en-GB renders "3 Sept 2026", en-US reorders the parts to
+ * "Sep 3, 2026") and this text is embedded in sentences on server- and
+ * client-rendered pages that must not disagree with each other.
+ */
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+/** Formats a UTC date as "3 Sep 2026", or null when unparseable. */
+function formatUtcDate(date: Date): string | null {
+  if (Number.isNaN(date.getTime())) return null;
+  return `${date.getUTCDate()} ${MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`;
+}
+
+/**
+ * "2026-09-03T12:40:11+00:00" -> "3 Sep 2026".
+ *
+ * UTC on purpose: run-log timestamps are UTC instants, and rendering them in
+ * the server's or visitor's timezone would make the same refresh show as
+ * different days depending on where the page was built or viewed.
+ */
+export function formatRunDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  return formatUtcDate(new Date(iso));
+}
+
+/** "2025-11-01" -> "1 Nov 2025". Window dates are date-only, not instants. */
+export function formatWindowDate(isoDate: string | null | undefined): string | null {
+  if (!isoDate) return null;
+  return formatUtcDate(new Date(`${isoDate}T00:00:00Z`));
+}
+
+/**
+ * {"start": "2025-11-01", "end": "2026-02-28"} -> "1 Nov 2025 – 28 Feb 2026".
+ * Returns null when either bound is missing or unparseable.
+ */
+export function formatCompositeWindow(
+  window: CompositeWindow | null | undefined
+): string | null {
+  if (!window) return null;
+  const start = formatWindowDate(window.start);
+  const end = formatWindowDate(window.end);
+  if (!start || !end) return null;
+  return `${start} – ${end}`;
+}

--- a/pipeline/02_gee_layers.py
+++ b/pipeline/02_gee_layers.py
@@ -38,13 +38,13 @@ Run:
 """
 
 import json
-import os
 import sys
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 
 import ee
 
+from _dry_season import most_recent_complete_dry_season
 from _gee_auth import init_ee, resolve_project
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
@@ -53,51 +53,13 @@ OUT_PATH = DATA_DIR / "grid_1km_gee.geojson"
 
 GEE_PROJECT = resolve_project()
 
-# Mumbai's dry season runs November to February. Monsoon imagery is unusable for
-# LST (cloud cover), so every composite in this pipeline is dry-season only, and
-# the current and baseline windows must cover the same months to be comparable.
-DRY_START_MONTH = 11  # November
-DRY_END_MONTH = 2  # February, of the following calendar year
-
 # How far back the NDVI-change baseline sits, in years. Roughly a decade gives a
 # green-cover trend long enough to be a real signal rather than year-to-year
 # weather.
 BASELINE_GAP_YEARS = 9
 
-
-def most_recent_complete_dry_season(today: date | None = None) -> tuple[str, str]:
-    """The latest Nov-Feb window that has actually finished, as ISO date strings.
-
-    The window used to be two hardcoded literals ("2025-11-01", "2026-02-28").
-    That made the pipeline perfectly reproducible, which is genuinely useful, but
-    it also made the monthly refresh in .github/workflows/pipeline-refresh.yml
-    incapable of ever refreshing anything: re-running it re-fetched the same
-    Landsat scenes and produced identical output, so the scheduled job would burn
-    Earth Engine quota and open a pull request of float noise every month,
-    forever. Confirmed on 2026-09-03 by running the full chain: every ward's HVI
-    came back identical to 15 decimal places.
-
-    Deriving the window from the calendar instead means a refresh run after
-    February picks up the season that just ended, and a run before it keeps
-    using the last complete one rather than averaging over a partial season.
-    Composites are never built from a season still in progress, because a
-    half-season mean is not comparable to a full-season baseline.
-
-    Override with GEE_DRY_SEASON_END_YEAR to reproduce a specific past run.
-    """
-    today = today or date.today()
-    # The season labelled Y ends in February of Y. It is complete once March of
-    # that year has started.
-    end_year = today.year if today.month > DRY_END_MONTH else today.year - 1
-    override = os.environ.get("GEE_DRY_SEASON_END_YEAR")
-    if override:
-        end_year = int(override)
-    start = date(end_year - 1, DRY_START_MONTH, 1)
-    # Last day of February, leap years included.
-    end = date(end_year, DRY_END_MONTH + 1, 1) - timedelta(days=1)
-    return start.isoformat(), end.isoformat()
-
-
+# The dry-season window logic lives in _dry_season.py, shared with
+# run_pipeline.py so the run log records the same window this stage composites.
 CURR_START, CURR_END = most_recent_complete_dry_season()
 # Older dry-season baseline for the F6 green-cover-change layer, the same months
 # a fixed number of years earlier so the two composites are comparable.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -20,7 +20,10 @@ python run_pipeline.py
 ```
 
 `run_pipeline.py` (issue #56) runs stages `01` through `12` in dependency order, stops at
-the first hard failure, and writes a run log to `data/pipeline_run_log.json`. Useful
+the first hard failure, and writes a run log to `data/pipeline_run_log.json` (mirrored to
+`frontend/public/`; see "Frontend sync" below). The log records when the run happened and
+the dry-season window it was computed from (issue #124), which is what the site's
+"data vintage" note shows. Useful
 flags:
 
 | Flag | Effect |
@@ -58,10 +61,18 @@ runtime writes to both places in the same run, not just `data/`:
 | `10_ward_profile.py` | `ward_profiles.json` | yes (already did this before #56) |
 | `11_hero_city.py` | `hero_city.json` | yes (already did this before #56) |
 | `12_hero_region.py` | `hero_region.json` | yes (already did this before #56) |
+| `run_pipeline.py` | `pipeline_run_log.json` | yes |
 
-`sensitivity.json` and `hvi_pca_log.json` are the two exceptions: the methodology page
-(`frontend/src/app/methodology/page.tsx`) reads them server-side straight out of
-`../data/`, so they need no `frontend/public/` copy at all. `sensitivity_chart.png` is
+The `run_pipeline.py` row is the orchestrator's own run log rather than a stage output:
+the dashboard footer and `/api/v1/meta` read it from `frontend/public/` (issue #124), and
+it rides the same automated refresh PR as every other file in the table.
+
+`sensitivity.json`, `hvi_pca_log.json` and `pipeline_run_log.json` are the exceptions to
+"the deployed frontend reads from `frontend/public/`": the methodology page reads all
+three server-side straight out of `../data/`, so they need no copy for that page — but
+`pipeline_run_log.json` still gets one, because `/api/v1/meta` and the dashboard footer
+(which are not the methodology page) read it from `frontend/public/` like every other
+route does. `sensitivity_chart.png` is
 different from `sensitivity.json` even though both come from `08_sensitivity.py`: the
 chart is rendered as a plain `<img src="/sensitivity_chart.png">`, a browser-fetched
 static asset, so it does need the copy.

--- a/pipeline/_dry_season.py
+++ b/pipeline/_dry_season.py
@@ -1,0 +1,64 @@
+"""The dry-season composite window, as a pure calendar function.
+
+Why this module exists: two callers need the same window and must not drift.
+
+    02_gee_layers.py computes the Landsat composites for this window, so it has
+    always owned the logic. run_pipeline.py now records the window a run was
+    made from in data/pipeline_run_log.json, because the site's "how old is this
+    data" story is only honest as a pair: *when* the pipeline last ran AND *what
+    imagery* that run was computed from. Copying the calendar arithmetic into the
+    orchestrator would let the two copies drift (different month constants, a
+    different leap-year rule, ...), which is exactly the failure this repo
+    extracts shared helpers to prevent (see _gee_auth.py and _publish.py).
+
+    Importing this module has no side effects and needs no Earth Engine: both
+    callers run it in environments where ee would be a heavy, sometimes
+    unavailable, dependency (run_pipeline.py is imported by CI unit tests that
+    never touch GEE), so the logic deliberately lives apart from 02's ee import.
+
+    Mumbai's dry season runs November to February. Monsoon imagery is unusable
+    for LST (cloud cover), so every composite in this pipeline is dry-season
+    only, and the current and baseline windows must cover the same months to be
+    comparable.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+
+DRY_START_MONTH = 11  # November
+DRY_END_MONTH = 2  # February, of the following calendar year
+
+
+def most_recent_complete_dry_season(today: date | None = None) -> tuple[str, str]:
+    """The latest Nov-Feb window that has actually finished, as ISO date strings.
+
+    The window used to be two hardcoded literals ("2025-11-01", "2026-02-28").
+    That made the pipeline perfectly reproducible, which is genuinely useful, but
+    it also made the monthly refresh in .github/workflows/pipeline-refresh.yml
+    incapable of ever refreshing anything: re-running it re-fetched the same
+    Landsat scenes and produced identical output, so the scheduled job would burn
+    Earth Engine quota and open a pull request of float noise every month,
+    forever. Confirmed on 2026-09-03 by running the full chain: every ward's HVI
+    came back identical to 15 decimal places.
+
+    Deriving the window from the calendar instead means a refresh run after
+    February picks up the season that just ended, and a run before it keeps
+    using the last complete one rather than averaging over a partial season.
+    Composites are never built from a season still in progress, because a
+    half-season mean is not comparable to a full-season baseline.
+
+    Override with GEE_DRY_SEASON_END_YEAR to reproduce a specific past run.
+    """
+    today = today or date.today()
+    # The season labelled Y ends in February of Y. It is complete once March of
+    # that year has started.
+    end_year = today.year if today.month > DRY_END_MONTH else today.year - 1
+    override = os.environ.get("GEE_DRY_SEASON_END_YEAR")
+    if override:
+        end_year = int(override)
+    start = date(end_year - 1, DRY_START_MONTH, 1)
+    # Last day of February, leap years included.
+    end = date(end_year, DRY_END_MONTH + 1, 1) - timedelta(days=1)
+    return start.isoformat(), end.isoformat()

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -58,9 +58,17 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from _dry_season import most_recent_complete_dry_season
+from _publish import publish
+
 PIPELINE_DIR = Path(__file__).resolve().parent
 DATA_DIR = PIPELINE_DIR.parent / "data"
 RUN_LOG_PATH = DATA_DIR / "pipeline_run_log.json"
+# Mirror for the deployed site, which reads data from frontend/public/ (issue
+# #124); see the "Frontend sync" section of pipeline/README.md.
+RUN_LOG_PUBLIC_PATH = (
+    PIPELINE_DIR.parent / "frontend" / "public" / "pipeline_run_log.json"
+)
 
 
 @dataclass
@@ -148,12 +156,20 @@ class StageResult:
 class RunReport:
     started_at: str
     finished_at: str | None = None
+    # The dry-season Landsat composite window (see _dry_season.py) this run was
+    # made from, as {"start": ..., "end": ...} ISO dates. The site shows the
+    # refresh date and this window as one statement (issue #124), so the run log
+    # is where the window is recorded: the orchestrator and stage 02 share the
+    # same calendar function, and a consumer never has to know which stage
+    # produced it.
+    composite_window: dict[str, str] | None = None
     results: list[StageResult] = field(default_factory=list)
 
     def to_json(self) -> dict:
         return {
             "started_at": self.started_at,
             "finished_at": self.finished_at,
+            "composite_window": self.composite_window,
             "stages": [
                 {
                     "id": r.stage.id,
@@ -251,7 +267,13 @@ def main() -> int:
     for s in stages:
         print(f"  [{s.id}] {s.script:<20s} ({s.cadence})")
 
-    report = RunReport(started_at=datetime.now(timezone.utc).isoformat())
+    # Same function stage 02 calls when it builds its composites, so the window
+    # recorded here always matches the window the run actually used.
+    window_start, window_end = most_recent_complete_dry_season()
+    report = RunReport(
+        started_at=datetime.now(timezone.utc).isoformat(),
+        composite_window={"start": window_start, "end": window_end},
+    )
     exit_code = 0
     for stage in stages:
         result = run_stage(stage, args.dry_run)
@@ -269,6 +291,13 @@ def main() -> int:
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         RUN_LOG_PATH.write_text(json.dumps(report.to_json(), indent=2), encoding="utf-8")
         print(f"\n[ok] wrote run log -> {RUN_LOG_PATH}")
+        # Mirror the log where the deployed site reads data from
+        # (frontend/public/, issue #124): /api/v1/meta and the dashboard footer
+        # serve it from there, exactly like the stage outputs in the "Frontend
+        # sync" table in pipeline/README.md. The methodology page reads the
+        # data/ copy server-side instead, like sensitivity.json and
+        # hvi_pca_log.json.
+        publish(RUN_LOG_PATH, RUN_LOG_PUBLIC_PATH)
 
     print("\n" + "-" * 70)
     print("Summary:")

--- a/pipeline/tests/test_run_pipeline.py
+++ b/pipeline/tests/test_run_pipeline.py
@@ -84,3 +84,24 @@ def test_stage_result_status_derived_from_returncode():
     assert rp.StageResult(stage, 1, 1.0).status == "fail"
     assert rp.StageResult(stage, 137, 1.0).status == "fail"
     assert rp.StageResult(stage, None, 0.0).status == "skipped"
+
+
+def test_run_report_serialises_composite_window():
+    """The run log records the dry-season window alongside the run's timestamps
+    (issue #124), so the site can show "refreshed X from imagery captured
+    between A and B" as one statement."""
+    report = rp.RunReport(
+        started_at="2026-09-03T04:00:00+00:00",
+        composite_window={"start": "2025-11-01", "end": "2026-02-28"},
+    )
+    log = report.to_json()
+    assert log["composite_window"] == {"start": "2025-11-01", "end": "2026-02-28"}
+    assert log["started_at"] == "2026-09-03T04:00:00+00:00"
+    assert log["finished_at"] is None
+    assert log["stages"] == []
+
+
+def test_run_log_window_uses_the_shared_dry_season_helper():
+    """run_pipeline must record the same window stage 02 composites, not a copy
+    that could drift: the function it calls is the one defined in _dry_season.py."""
+    assert rp.most_recent_complete_dry_season.__module__ == "_dry_season"


### PR DESCRIPTION
## What & why

Closes #124 — the site never said how old its data was. Before the dry-season window fix, published figures were roughly seven weeks old and nobody could have known from the interface.

This change makes the pipeline run log the site's source of truth for data age, and surfaces it in two places the issue asked for, always as the honest pair: **when the pipeline last refreshed** + **which dry-season Landsat window the figures were computed from**.

## Changes

**Pipeline** (`pipeline/`)
- Extracted the dry-season window calendar logic from `02_gee_layers.py` into `_dry_season.py`, so `run_pipeline.py` and stage 02 share one implementation and cannot drift. Module is ee-free with no side effects (CI unit tests import `run_pipeline.py` without GEE).
- `run_pipeline.py` now records `composite_window` (`{start, end}`) in the run log and mirrors `data/pipeline_run_log.json` to `frontend/public/pipeline_run_log.json`, exactly like the stage outputs in the README's "Frontend sync" table. Both paths already ride the automated refresh PR's `add-paths`, so the site updates with no extra wiring.
- `pipeline/README.md` updated (frontend-sync table + run-log description); `pipeline/tests/test_run_pipeline.py` covers the new serialisation.

**API** (`frontend/src/app/api/v1/meta`)
- `/api/v1/meta` now returns `generated_at` (end of last run) and `composite_window`. Its docstring already claimed to report these — the endpoint now actually does.

**UI** (`frontend/`)
- `/methodology`: a "Data vintage" card — *"Refreshed 3 Sep 2026 … imagery captured 1 Nov 2025 – 28 Feb 2026"*.
- Dashboard: a slim footer bar with the same statement.
- Shared, deterministic UTC formatters in `src/lib/runLog.ts` (hand-rolled month names: `Intl` abbreviates differently per locale, and server- and client-rendered pages must agree).

## Verification

- `pytest pipeline/tests/` → 73 passed, 1 skipped (pre-existing).
- `npm run lint`, `npm test` (175 passed), `npm run build` → all green.
- Visually confirmed locally (dev server + a temporary run log): the methodology card, the dashboard footer bar, and the new `/api/v1/meta` fields all render/return correctly.

## One thing to know (by design)

No `pipeline_run_log.json` is committed yet because no real refresh has ever run end-to-end (the workflow is explicitly "NOT verified end-to-end" until repo secrets are configured). Until the first refresh commits its log, the UI renders nothing rather than inventing a date. From the first refresh on, the date appears and then updates itself every month. If you'd like the current site to show something immediately, the cleanest route is to run a refresh once (local full-chain run or `workflow_dispatch` once secrets are set) and let the automated PR carry the log in.

## Checklist

- [ ] Issue referenced (`Closes #124`)
- [ ] Pipeline tests pass
- [ ] Frontend lint / tests / build pass
- [ ] Docs (pipeline README, docs/api.md, CHANGELOG) updated
