### PR TITLE
feat(dashboard): add find-my-ward via browser geolocation (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ yet — this section covers everything since the project started.
   imagery window it was computed from (surfaced from the pipeline run log via
   /api/v1/meta; issue #124). The pipeline run log now records that window and is mirrored
   to `frontend/public/`, so the note updates itself on every refresh.
+- Find-my-ward on the dashboard: a locate button on the map resolves the visitor's
+  position to the BMC ward containing it via /api/v1/lookup, one tap after arrival (no
+  permission prompt on load), with graceful handling of denial, unavailability, timeout
+  and positions outside Mumbai (issue #116).
 - End-to-end data pipeline: dry-season Landsat 8/9 LST + NDVI composite, WorldPop
   population/elderly layer (pinned to the 2020 vintage), OSM hospital distance, Datameet
   ward + slum-cluster boundaries.

--- a/frontend/src/app/components/WardChoropleth.tsx
+++ b/frontend/src/app/components/WardChoropleth.tsx
@@ -6,7 +6,7 @@ import { GeoJSON, MapContainer, TileLayer, useMap } from "react-leaflet";
 import { geoJSON as leafletGeoJSON } from "leaflet";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { GeoJSON as LeafletGeoJSONLayer, Layer, Path, PathOptions } from "leaflet";
-import { Maximize2, Minimize2 } from "lucide-react";
+import { Loader2, LocateFixed, Maximize2, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -242,11 +242,20 @@ export default function WardChoropleth({
   onSelectWard,
   isFullscreen = false,
   onToggleFullscreen,
+  locating = false,
+  locateError = null,
+  onLocate,
 }: {
   selectedWardId?: string | null;
   onSelectWard?: (wardId: string) => void;
   isFullscreen?: boolean;
   onToggleFullscreen?: () => void;
+  /** True while the dashboard's find-my-ward flow is running (issue #116). */
+  locating?: boolean;
+  /** A user-facing find-my-ward failure message, shown over the map. */
+  locateError?: string | null;
+  /** Requests "find the ward I'm in". Only rendered when provided. */
+  onLocate?: () => void;
 }) {
   const [activeLayer, setActiveLayer] = useState<LayerId>("hvi");
   const [cache, setCache] = useState<Partial<Record<LayerId, FeatureCollection>>>({});
@@ -341,6 +350,25 @@ export default function WardChoropleth({
               ))}
             </TabsList>
           </Tabs>
+          {onLocate && (
+            <>
+              <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onLocate}
+                disabled={locating}
+                aria-label={locating ? "Finding your ward…" : "Find my ward"}
+                title={locating ? "Finding your ward…" : "Find my ward — use your location"}
+              >
+                {locating ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <LocateFixed className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </>
+          )}
           {onToggleFullscreen && (
             <Button
               variant="ghost"
@@ -361,9 +389,23 @@ export default function WardChoropleth({
 
       <Legend layer={activeLayer} />
 
-      {error && (
-        <div className="absolute inset-x-0 top-12 z-[1000] mx-auto w-fit rounded bg-destructive/10 px-3 py-1 text-sm text-destructive">
-          Failed to load layer: {error}
+      {(error || locateError) && (
+        <div className="absolute inset-x-0 top-12 z-[1000] mx-auto flex w-fit max-w-[90%] flex-col items-center gap-1">
+          {error && (
+            <div className="rounded bg-destructive/10 px-3 py-1 text-sm text-destructive">
+              Failed to load layer: {error}
+            </div>
+          )}
+          {locateError && (
+            <div
+              // Announce the failure rather than leaving a screen-reader user
+              // with a button that silently did nothing (issue #116).
+              role="status"
+              className="rounded border border-border bg-background/95 px-3 py-1 text-center text-sm text-foreground backdrop-blur-sm"
+            >
+              {locateError}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,6 +15,11 @@ import {
   toggleWard,
   writeStoredWards,
 } from "@/lib/savedWards";
+import {
+  findMyWard,
+  isLocateFailure,
+  LOCATE_ERROR_MESSAGE,
+} from "@/lib/findWard";
 
 const WardChoropleth = dynamic(() => import("../components/WardChoropleth"), {
   ssr: false,
@@ -98,6 +103,27 @@ function DashboardContent() {
     [searchParams]
   );
   const [isFullscreen, setIsFullscreen] = useState(false);
+  /** Find-my-ward (issue #116): state for the map's locate button. */
+  const [locating, setLocating] = useState(false);
+  const [locateError, setLocateError] = useState<string | null>(null);
+
+  async function locateMe() {
+    // Only ever called from the button's click handler, so the browser's
+    // location permission prompt is tied to a user gesture and never fires on
+    // page load.
+    setLocating(true);
+    setLocateError(null);
+    try {
+      const wardId = await findMyWard();
+      selectWard(wardId);
+    } catch (err) {
+      setLocateError(
+        isLocateFailure(err) ? LOCATE_ERROR_MESSAGE[err.kind] : LOCATE_ERROR_MESSAGE.lookup
+      );
+    } finally {
+      setLocating(false);
+    }
+  }
   const sidebarVisible = useSyncExternalStore(
     subscribeSidebar,
     getSidebarSnapshot,
@@ -194,6 +220,9 @@ function DashboardContent() {
             onSelectWard={selectWard}
             isFullscreen={isFullscreen}
             onToggleFullscreen={() => setIsFullscreen((v) => !v)}
+            locating={locating}
+            locateError={locateError}
+            onLocate={locateMe}
           />
         </div>
         {!isFullscreen && (

--- a/frontend/src/lib/findWard.test.ts
+++ b/frontend/src/lib/findWard.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findMyWard,
+  LOCATE_ERROR_MESSAGE,
+  lookupWard,
+  requestLocation,
+} from "./findWard";
+import type { LocateFailureKind } from "./findWard";
+
+/**
+ * Temporarily replaces navigator.geolocation. jsdom has no geolocation at all,
+ * so every stub must be configurable for the next stub (or the delete below)
+ * to replace it.
+ */
+function stubGeolocation(impl: Geolocation["getCurrentPosition"]): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "geolocation");
+  Object.defineProperty(navigator, "geolocation", {
+    value: { getCurrentPosition: impl },
+    configurable: true,
+  });
+  return () => {
+    if (original) Object.defineProperty(navigator, "geolocation", original);
+    else delete (navigator as { geolocation?: unknown }).geolocation;
+  };
+}
+
+/** Removes any geolocation stub so the "no API at all" state is real. */
+function removeGeolocationStub() {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "geolocation");
+  if (descriptor) delete (navigator as { geolocation?: unknown }).geolocation;
+}
+
+function positionError(code: number): GeolocationPositionError {
+  // GeolocationPositionError is not constructible in jsdom; its shape is what
+  // matters (the module reads only `code`).
+  return { code, PERMISSION_DENIED: 1, POSITION_UNAVAILABLE: 2, TIMEOUT: 3 } as unknown as GeolocationPositionError;
+}
+
+function okPosition(lat = 19.076, lng = 72.877): GeolocationPosition {
+  return {
+    coords: {
+      latitude: lat,
+      longitude: lng,
+      accuracy: 20,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null,
+    },
+    timestamp: Date.now(),
+  } as GeolocationPosition;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("requestLocation", () => {
+  it("resolves coordinates when the browser returns a fix", async () => {
+    const restore = stubGeolocation((onOk) => onOk(okPosition(19.076, 72.877)));
+    try {
+      await expect(requestLocation()).resolves.toEqual({ lat: 19.076, lng: 72.877 });
+    } finally {
+      restore();
+    }
+  });
+
+  it("fails with kind 'unsupported' when there is no geolocation API", async () => {
+    removeGeolocationStub(); // jsdom ships no geolocation; exercise that state.
+    await expect(requestLocation()).rejects.toEqual({ kind: "unsupported" });
+  });
+
+  it("maps each position-error code to the right failure kind", async () => {
+    const expectations: Array<[number, LocateFailureKind]> = [
+      [1, "denied"],
+      [2, "unavailable"],
+      [3, "timeout"],
+    ];
+    for (const [code, kind] of expectations) {
+      removeGeolocationStub();
+      const restore = stubGeolocation((_ok, onErr) => onErr(positionError(code)));
+      try {
+        await expect(requestLocation()).rejects.toEqual({ kind });
+      } finally {
+        restore();
+      }
+    }
+  });
+});
+
+describe("lookupWard", () => {
+  it("resolves the ward id from a 200 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ward: { ward_id: "L" } }), { status: 200 })
+      )
+    );
+    await expect(lookupWard(19.076, 72.877)).resolves.toEqual({ ward_id: "L" });
+    const url = String(vi.mocked(fetch).mock.calls[0]?.[0]);
+    expect(url).toContain("/api/v1/lookup?lat=19.076&lon=72.877");
+  });
+
+  it("fails with kind 'outside' on a 404", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+    await expect(lookupWard(0, 0)).rejects.toEqual({ kind: "outside" });
+  });
+
+  it("fails with kind 'lookup' on other errors and on network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    await expect(lookupWard(19.076, 72.877)).rejects.toEqual({ kind: "lookup" });
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("offline")));
+    await expect(lookupWard(19.076, 72.877)).rejects.toEqual({ kind: "lookup" });
+  });
+});
+
+describe("findMyWard", () => {
+  it("runs geolocation then lookup and returns the ward id", async () => {
+    const restore = stubGeolocation((onOk) => onOk(okPosition(19.076, 72.877)));
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ ward: { ward_id: "L" } }), { status: 200 })
+        )
+      );
+      await expect(findMyWard()).resolves.toBe("L");
+    } finally {
+      restore();
+    }
+  });
+
+  it("propagates a permission denial without calling the lookup", async () => {
+    const restore = stubGeolocation((_ok, onErr) => onErr(positionError(1)));
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await expect(findMyWard()).rejects.toEqual({ kind: "denied" });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("LOCATE_ERROR_MESSAGE", () => {
+  it("has copy for every failure kind", () => {
+    const kinds: LocateFailureKind[] = [
+      "unsupported",
+      "denied",
+      "unavailable",
+      "timeout",
+      "outside",
+      "lookup",
+    ];
+    for (const kind of kinds) {
+      expect(LOCATE_ERROR_MESSAGE[kind]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/lib/findWard.ts
+++ b/frontend/src/lib/findWard.ts
@@ -1,0 +1,127 @@
+/**
+ * Find-my-ward plumbing (issue #116): turn the browser's location into a BMC
+ * ward id.
+ *
+ * Two pure, testable steps, wired together by the dashboard's "find my ward"
+ * button: geolocation (navigator.geolocation) -> /api/v1/lookup -> ward id.
+ * Everything here is deliberately UI-free. The policy decisions that matter to
+ * users — only asking for location on a button tap, never on page load, and
+ * wording every refusal without blaming the user — live with the caller, which
+ * is also where the button's loading/disabled state is owned.
+ *
+ * Failures are typed as {@link LocateFailure} so the caller can render the
+ * right message instead of sniffing strings. {@link LOCATE_ERROR_MESSAGE}
+ * keeps that copy in one place.
+ */
+
+/** Why "where am I" failed, from the user's point of view. */
+export type LocateFailureKind =
+  | "unsupported" // no geolocation API at all
+  | "denied" // user refused the permission prompt
+  | "unavailable" // permission granted, position unknown
+  | "timeout" // position did not arrive in time
+  | "outside" // position resolved, but not inside any BMC ward
+  | "lookup"; // the ward lookup failed for another reason
+
+export interface LocateFailure {
+  kind: LocateFailureKind;
+}
+
+/** Copy for each failure kind, one sentence, no jargon. */
+export const LOCATE_ERROR_MESSAGE: Record<LocateFailureKind, string> = {
+  unsupported: "Location isn't available in this browser.",
+  denied: "Location permission was denied. You can pick your ward from the list instead.",
+  unavailable: "Your location couldn't be determined right now.",
+  timeout: "Finding your location timed out. Try again.",
+  outside: "You're outside the 24 BMC wards, so there's no ward here.",
+  lookup: "Couldn't look up your ward. Try again in a moment.",
+};
+
+export function isLocateFailure(value: unknown): value is LocateFailure {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    typeof (value as LocateFailure).kind === "string"
+  );
+}
+
+function positionErrorKind(error: GeolocationPositionError): LocateFailure {
+  // GeolocationPositionError codes are 1 (denied), 2 (unavailable), 3 (timeout).
+  switch (error.code) {
+    case 1:
+      return { kind: "denied" };
+    case 2:
+      return { kind: "unavailable" };
+    case 3:
+      return { kind: "timeout" };
+    default:
+      return { kind: "unavailable" };
+  }
+}
+
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Requests the current position, resolving to coordinates or rejecting with a
+ * {@link LocateFailure}. Called from a click handler only — never from an
+ * effect — so the browser's permission prompt is tied to a user gesture.
+ *
+ * The timeout and maximumAge are deliberate: a 10s cap stops a slow fix from
+ * hanging the button forever, and maximumAge accepts a cached fix from the
+ * last few minutes — still accurate enough for a ward lookup, which only
+ * needs to know which of the 24 wards contains the visitor.
+ */
+export function requestLocation(): Promise<LatLng> {
+  return new Promise((resolve, reject) => {
+    if (typeof navigator === "undefined" || !("geolocation" in navigator)) {
+      reject({ kind: "unsupported" } satisfies LocateFailure);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) =>
+        resolve({ lat: position.coords.latitude, lng: position.coords.longitude }),
+      (error) => reject(positionErrorKind(error)),
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 5 * 60 * 1000 }
+    );
+  });
+}
+
+export interface WardHit {
+  ward_id: string;
+}
+
+/**
+ * Resolves a coordinate to its containing ward via GET /api/v1/lookup.
+ * A 404 means the point is outside the 24 BMC wards; anything else non-OK or
+ * malformed is treated as a lookup failure rather than guessed at.
+ */
+export async function lookupWard(lat: number, lng: number): Promise<WardHit> {
+  const params = new URLSearchParams({ lat: String(lat), lon: String(lng) });
+  let res: Response;
+  try {
+    res = await fetch(`/api/v1/lookup?${params.toString()}`);
+  } catch {
+    throw { kind: "lookup" } satisfies LocateFailure;
+  }
+  if (res.status === 404) throw { kind: "outside" } satisfies LocateFailure;
+  if (!res.ok) throw { kind: "lookup" } satisfies LocateFailure;
+  const data = (await res.json().catch(() => null)) as {
+    ward?: WardHit;
+  } | null;
+  if (!data?.ward?.ward_id) throw { kind: "lookup" } satisfies LocateFailure;
+  return { ward_id: data.ward.ward_id };
+}
+
+/**
+ * The whole find-my-ward flow: location fix, then ward lookup. Resolves to the
+ * containing ward id, rejects with a {@link LocateFailure}.
+ */
+export async function findMyWard(): Promise<string> {
+  const { lat, lng } = await requestLocation();
+  const { ward_id } = await lookupWard(lat, lng);
+  return ward_id;
+}


### PR DESCRIPTION
## What & why

Closes #116 — a resident opening the dashboard had to already know their BMC ward code. This adds find-my-ward: one tap on a locate button (map layer control, visible on every viewport including fullscreen) → browser geolocation → the existing `/api/v1/lookup` endpoint → that ward is selected, exactly as if chosen from the list.

## Behaviour details (per the issue)

- **Location is only requested from the button's click handler** — never on page load, so no hostile permission prompt on arrival.
- **Refusal and unavailability are handled gracefully**, each with its own message shown over the map: no geolocation API, permission denied, position unavailable, timeout (10s cap), and "outside the 24 BMC wards" (lookup 404). The button resets to idle afterwards.
- Loading state disables the button (`Finding your ward…`).

## Changes

- `frontend/src/lib/findWard.ts` — pure, testable plumbing: `requestLocation()` (typed failures from `navigator.geolocation`), `lookupWard(lat, lng)` (`/api/v1/lookup`, 404 → `outside`), `findMyWard()`, and the `LOCATE_ERROR_MESSAGE` copy map.
- `frontend/src/app/dashboard/page.tsx` — owns the locate flow (loading/error state) and reuses the existing `selectWard()` URL-driven selection, so map fly-to, sidebar and mobile dialog all work unchanged.
- `frontend/src/app/components/WardChoropleth.tsx` — new optional `locating` / `locateError` / `onLocate` props; renders the locate button next to the fullscreen toggle and a banner for locate errors. Optional props keep the component usable/decoupled elsewhere.
- `frontend/src/lib/findWard.test.ts` — 9 unit tests: success, unsupported, all three position-error codes, 404/503/network lookup failures, full flow, denial never calling the lookup, and complete error copy.
- CHANGELOG updated.

## Verification

- `npm run lint`, `npm test` (175 passed incl. the 9 new), `npm run build` — all green.
- Live in the browser: button appears on the map control; with geolocation stubbed to 19.076, 72.877 it navigated to `/dashboard?ward=L` and opened Ward L's detail (sidebar/dialog). Without a fix available the banner showed *"Your location couldn't be determined right now."* and the button re-enabled.

Closes #116
