### PR TITLE
fix(pipeline): diff refreshes against the last merged refresh, via a git tag (#126)

### DIFF
--- a/.github/workflows/pipeline-refresh.yml
+++ b/.github/workflows/pipeline-refresh.yml
@@ -18,14 +18,20 @@
 #   NEXT_PUBLIC_SUPABASE_URL    Supabase project URL
 #   SUPABASE_SERVICE_ROLE_KEY   Supabase service-role key (server-side upsert only)
 #
-# Known limitation: the diff baseline (see "Snapshot pre-refresh data/" below) is
-# whatever's committed on main when this workflow starts, not necessarily the last
-# MERGED refresh. If a previous automated-refresh PR is still open when the next
-# scheduled run fires, that run diffs against the same stale baseline again instead of
-# against the (still unmerged) previous refresh, so its diff can double-count changes
-# already sitting in the open PR. Not fixed here: doing so needs somewhere to persist
-# "the last refresh actually merged" (e.g. a git tag updated on merge), which is a
-# bigger change than this workflow's first version.
+# Diff baseline (issue #126): a refresh diffs its output against the LAST refresh
+# that actually landed, never against whatever happens to sit on main — see the
+# "Snapshot pre-refresh data/" step below, which picks, in order:
+#   1. origin/automated/pipeline-refresh  — a previous refresh whose PR is still
+#      open. Diffing against it means a run that fires before the previous PR
+#      merges produces non-overlapping changes instead of re-diffing against the
+#      same stale baseline.
+#   2. the data-refresh-baseline tag       — the last refresh that MERGED. The tag
+#      is moved by refresh-baseline-tag.yml whenever an automated refresh PR
+#      merges, so a run never attributes human data edits made between refreshes
+#      to the pipeline.
+#   3. main itself                        — only when neither exists yet (first run).
+# This used to be "copy data/" plain, which double-counted changes from an open
+# refresh PR; fixed by refresh-baseline-tag.yml (issue #126).
 
 name: Pipeline refresh
 
@@ -67,9 +73,29 @@ jobs:
 
       - name: Snapshot pre-refresh data/ as the diff baseline
         # diff_snapshots.py (#61) needs the PREVIOUS run's output to compare
-        # against. Copying it before run_pipeline.py overwrites data/ is the
-        # cheapest way to have both "before" and "after" on disk at once.
-        run: cp -r data data-baseline
+        # against. "Previous" is decided by refresh-baseline-tag.yml (issue
+        # #126), not by the state of main: see the header comment above. The
+        # baseline is materialised into data-baseline/ via git archive so this
+        # step never touches the working data/ files the pipeline is about to
+        # regenerate.
+        run: |
+          rm -rf data-baseline
+          git fetch --tags --force --quiet origin
+          git fetch --quiet origin automated/pipeline-refresh || true
+          if git rev-parse --quiet --verify origin/automated/pipeline-refresh > /dev/null 2>&1; then
+            BASELINE_REF=origin/automated/pipeline-refresh
+            echo "Diff baseline: open refresh branch (previous refresh not merged yet)"
+          elif git rev-parse --quiet --verify refs/tags/data-refresh-baseline > /dev/null 2>&1; then
+            BASELINE_REF=data-refresh-baseline
+            echo "Diff baseline: last merged refresh (tag data-refresh-baseline)"
+          else
+            echo "Diff baseline: current main (first run, no merged refresh yet)"
+            cp -r data data-baseline
+            exit 0
+          fi
+          mkdir -p data-baseline
+          git archive --format=tar "$BASELINE_REF" data \
+            | tar -x -C data-baseline --strip-components=1
 
       - name: Resolve GEE_PROJECT
         # An unconfigured secrets.* reference substitutes as an empty string, not as

--- a/.github/workflows/pipeline-refresh.yml
+++ b/.github/workflows/pipeline-refresh.yml
@@ -60,6 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The diff baseline below can be any earlier commit or tag (git
+          # fetch --tags, then git archive of it), so the default shallow
+          # depth-1 clone is not enough — fetch full history once.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:
@@ -81,7 +86,18 @@ jobs:
         run: |
           rm -rf data-baseline
           git fetch --tags --force --quiet origin
-          git fetch --quiet origin automated/pipeline-refresh || true
+          # Priority 1 needs a real remote-tracking ref, but actions/checkout
+          # configures a single-branch refspec (only main is tracked), so a
+          # plain `git fetch origin automated/pipeline-refresh` would write
+          # FETCH_HEAD and nothing else and the rev-parse below could never
+          # fire. Fetch into the tracking ref explicitly instead (issue #126).
+          # Caveat: if the previous refresh PR is ever closed WITHOUT merging,
+          # its branch can be left behind and would keep being preferred here
+          # even though it never landed. Benign in practice — the next refresh
+          # that actually merges force-moves the tag and delete-branch removes
+          # the branch — but it means one diff is computed against an unmerged
+          # refresh.
+          git fetch --quiet origin '+refs/heads/automated/pipeline-refresh:refs/remotes/origin/automated/pipeline-refresh' || true
           if git rev-parse --quiet --verify origin/automated/pipeline-refresh > /dev/null 2>&1; then
             BASELINE_REF=origin/automated/pipeline-refresh
             echo "Diff baseline: open refresh branch (previous refresh not merged yet)"

--- a/.github/workflows/refresh-baseline-tag.yml
+++ b/.github/workflows/refresh-baseline-tag.yml
@@ -36,6 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Default checkout on a pull_request event is refs/pull/<n>/merge —
+          # GitHub's throwaway test-merge commit, which is not on main. The tag
+          # must bookmark the actual merge commit this event is announcing, so
+          # check that commit out explicitly.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Move data-refresh-baseline to the merge commit
         run: |

--- a/.github/workflows/refresh-baseline-tag.yml
+++ b/.github/workflows/refresh-baseline-tag.yml
@@ -1,0 +1,44 @@
+# Move the data-refresh-baseline tag when an automated refresh merges (issue #126).
+#
+# pipeline-refresh.yml diffs every scheduled run against \"the last refresh that
+# actually landed\". This workflow is what makes \"landed\" precise: the moment an
+# automated refresh PR (the ones pipeline-refresh.yml opens on branch
+# automated/pipeline-refresh) is merged, the lightweight tag data-refresh-baseline
+# is force-moved to that merge commit. The next scheduled refresh then diffs
+# against it (or against an even newer open refresh branch) instead of against
+# whatever happens to be on main, so it can neither double-count an unmerged
+# refresh's changes nor blame the pipeline for human data edits between
+# refreshes.
+#
+# Lightweight tag on purpose: it is a bookmark for \"this commit is a complete
+# published refresh\", not a release — it is force-moved on every refresh merge,
+# never versioned.
+#
+# Why pull_request.closed and not push-to-main: the push event cannot tell a
+# refresh merge from any other merge, and pinning \"merged branch was named
+# automated/pipeline-refresh\" is exactly the right filter — only refresh PRs
+# should move the baseline. Merges performed manually from any other branch
+# intentionally leave the tag untouched.
+
+name: Update refresh baseline tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  move-tag:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'automated/pipeline-refresh'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Move data-refresh-baseline to the merge commit
+        run: |
+          git tag -f data-refresh-baseline
+          git push --force origin refs/tags/data-refresh-baseline
+          echo "data-refresh-baseline -> $(git rev-parse --short HEAD) (merge of automated/pipeline-refresh)"


### PR DESCRIPTION
## What & why

Closes #126 — the fix for the limitation `pipeline-refresh.yml` itself documented: the diff baseline was whatever sat on main when a run started, so a run firing while the previous refresh PR was still open re-diffed against the same stale baseline and could double-count changes already sitting in the open PR. The issue's suggested fix, implemented here: persist "the last refresh that actually merged" as a git tag updated on merge, and diff against that.

## Changes

**`.github/workflows/refresh-baseline-tag.yml`** (new) — when an automated refresh PR (`head.ref == automated/pipeline-refresh`) **merges**, force-move a lightweight tag `data-refresh-baseline` to the merge commit. Gated on the merged branch name so only refresh merges move the baseline; `pull_request.closed` rather than push-to-main because a push event cannot distinguish a refresh merge from any other merge.

**`.github/workflows/pipeline-refresh.yml`** — the "Snapshot pre-refresh data/" step now materialises its baseline from, in order:

1. `origin/automated/pipeline-refresh` — a previous refresh whose PR is still open. Diffing against the still-unmerged refresh means a run that fires before that PR merges produces **non-overlapping** changes instead of re-diffing against the same stale baseline (this is the acceptance criterion's case).
2. `data-refresh-baseline` tag — the last refresh that actually merged, so a run never attributes human data edits made between refreshes to the pipeline.
3. main itself — only when neither exists yet (the very first run).

The baseline is materialised into `data-baseline/` via `git archive | tar --strip-components=1`, so the working `data/` files the pipeline is about to regenerate are never touched (the old `cp -r` approach had no such guarantee once a tag/remote checkout became involved). The stale "Known limitation" header comment is replaced with a description of the new behaviour.

## Verification

- The baseline-materialisation command was exercised locally against this repo's own `data/` (archive → `data-baseline/`, 25 files, working tree untouched).
- End-to-end (merge → tag move → next scheduled run picking the right baseline) only executes on the real GitHub runner with the refresh workflow's credentials; the two workflows are deliberately small and each step is a single well-tested git command. The first real monthly refresh after this merges will exercise it end to end.

Closes #126
